### PR TITLE
feat: StoryInterface full layout control, {passage} macro, and widget arguments

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,10 +28,52 @@ export default defineConfig({
         text: 'Authoring',
         items: [
           { text: 'Markup', link: '/markup' },
-          { text: 'Macros', link: '/macros' },
+          {
+            text: 'Macros',
+            link: '/macros',
+            collapsed: true,
+            items: [
+              { text: 'Control Flow', link: '/macros#control-flow' },
+              { text: 'Variables', link: '/macros#variables' },
+              { text: 'Output', link: '/macros#output' },
+              { text: 'Navigation', link: '/macros#navigation' },
+              { text: 'Form Inputs', link: '/macros#form-inputs' },
+              { text: 'Timing', link: '/macros#timing' },
+              { text: 'Composition', link: '/macros#composition' },
+              { text: 'Saves and UI', link: '/macros#saves-and-ui' },
+            ],
+          },
           { text: 'Variables', link: '/variables' },
-          { text: 'Special Passages', link: '/special-passages' },
-          { text: 'Widgets', link: '/widgets' },
+          {
+            text: 'Special Passages',
+            link: '/special-passages',
+            collapsed: true,
+            items: [
+              { text: 'StoryInit', link: '/special-passages#storyinit' },
+              {
+                text: 'StoryVariables',
+                link: '/special-passages#storyvariables',
+              },
+              {
+                text: 'StoryInterface',
+                link: '/special-passages#storyinterface',
+              },
+              { text: 'SaveTitle', link: '/special-passages#savetitle' },
+            ],
+          },
+          { text: 'StoryInterface', link: '/story-interface' },
+          {
+            text: 'Widgets',
+            link: '/widgets',
+            collapsed: true,
+            items: [
+              { text: 'Defining a Widget', link: '/widgets#defining-a-widget' },
+              { text: 'Using a Widget', link: '/widgets#using-a-widget' },
+              { text: 'Arguments', link: '/widgets#arguments' },
+              { text: 'How Widgets Work', link: '/widgets#how-widgets-work' },
+              { text: 'Example', link: '/widgets#example' },
+            ],
+          },
         ],
       },
       {

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -423,13 +423,19 @@ The argument can be a literal passage name or an expression that evaluates to on
 
 ### `{widget}`
 
-Define a reusable content block. See [Widgets](widgets.md).
+Define a reusable content block. Optionally declare parameters after the name.
 
 ```
 {widget "StatusBar"}
   Health: {$health} | Mana: {$mana}
 {/widget}
+
+{widget "StatLine" $label $value $max}
+  **{$label}:** {$value} / {$max}
+{/widget}
 ```
+
+Invoke with arguments: `{StatLine "Health", $health, 100}`. See [Widgets](widgets.md).
 
 ## Saves and UI
 

--- a/docs/special-passages.md
+++ b/docs/special-passages.md
@@ -40,26 +40,17 @@ See [Variables](variables.md) for details.
 
 ## `StoryInterface`
 
-Override the default menubar. If this passage exists, its content replaces the built-in interface:
+Controls the entire page layout. When this passage exists, its content replaces the default UI — including the menubar and passage display area. Use the `{passage}` macro to place the current passage within your custom layout.
 
 ```
 :: StoryInterface
-<nav class="my-menubar">
-  {story-title}
-  {back}{forward}
-  {restart}
-  {saves}
-  {settings}
-</nav>
+<header class="story-menubar">
+  {story-title}{back}{forward}{restart}{saves}{settings}
+</header>
+{passage}
 ```
 
-The default menubar (when no `StoryInterface` passage exists) renders:
-
-```
-{story-title}{back}{forward}{restart}{quicksave}{quickload}{saves}{settings}
-```
-
-You can use any macros, HTML, and links in your custom interface. The interface is rendered once and does not change between passages.
+See [StoryInterface](story-interface.md) for full documentation, examples, and available macros.
 
 ## `SaveTitle`
 

--- a/docs/story-interface.md
+++ b/docs/story-interface.md
@@ -1,0 +1,147 @@
+# StoryInterface
+
+The `StoryInterface` passage gives you full control over the page layout. When defined, its content replaces the entire default UI — header, passage area, and everything in between.
+
+## Default Layout
+
+When no `StoryInterface` passage exists, Spindle renders this built-in layout:
+
+```
+<header class="story-menubar">
+  {story-title}{back}{forward}{restart}{quicksave}{quickload}{saves}{settings}
+</header>
+{passage}
+```
+
+This gives you a menubar at the top and the current passage below it. You can replicate and customize this by creating your own `StoryInterface` passage.
+
+## The `{passage}` Macro
+
+The `{passage}` macro renders the current passage display area. It automatically updates when the player navigates to a new passage and preserves the fade-in animation.
+
+By default it renders as:
+
+```html
+<div
+  id="story"
+  class="story"
+>
+  <!-- current passage content -->
+</div>
+```
+
+You can override the wrapper's `id` and `class` using the standard macro syntax:
+
+```
+{#my-story .custom-story passage}
+```
+
+This renders as `<div id="my-story" class="custom-story">` instead.
+
+::: warning
+If your `StoryInterface` passage does not contain `{passage}`, no passage content will be displayed. Spindle logs a warning to the browser console when this happens.
+:::
+
+## Basic Example
+
+A minimal custom interface that matches the default behavior:
+
+```
+:: StoryInterface
+<header class="story-menubar">
+  {story-title}
+  {back}{forward}
+  {restart}{saves}{settings}
+</header>
+{passage}
+```
+
+## Sidebar Layout
+
+Use HTML and CSS to create more complex layouts. This example adds a sidebar with a character status panel:
+
+```
+:: StoryInterface
+<div class="layout">
+  <aside class="sidebar">
+    {include "SidebarPanel"}
+  </aside>
+  <main>
+    <header class="story-menubar">
+      {story-title}{back}{forward}{saves}{settings}
+    </header>
+    {passage}
+  </main>
+</div>
+
+:: SidebarPanel
+**{$player_name}**
+HP: {$health} / {$max_health}
+Gold: {$gold}
+```
+
+With corresponding CSS in your Story Stylesheet:
+
+```css
+.layout {
+  display: flex;
+  height: 100vh;
+}
+
+.sidebar {
+  width: 250px;
+  padding: 1rem;
+  border-right: 1px solid #333;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+```
+
+The `{include}` macro is reactive — the sidebar updates automatically when variables change.
+
+## HUD Overlay
+
+You can layer UI elements over the passage area:
+
+```
+:: StoryInterface
+<header class="story-menubar">
+  {story-title}{saves}{settings}
+</header>
+<div class="game-container">
+  {passage}
+  <div class="hud">
+    {include "HUD"}
+  </div>
+</div>
+```
+
+## Available Macros
+
+All standard macros work inside `StoryInterface`:
+
+| Macro              | Description                        |
+| ------------------ | ---------------------------------- |
+| `{passage}`        | Current passage display area       |
+| `{story-title}`    | The story's title                  |
+| `{back}`           | Back button                        |
+| `{forward}`        | Forward button                     |
+| `{restart}`        | Restart button                     |
+| `{quicksave}`      | Quick save button                  |
+| `{quickload}`      | Quick load button                  |
+| `{saves}`          | Save/load dialog button            |
+| `{settings}`       | Settings dialog button             |
+| `{include "Name"}` | Include another passage (reactive) |
+
+You can also use `{if}`, `{for}`, variables, links, and any other Spindle markup.
+
+## Tips
+
+- Use the `story-menubar` class on your header element to get the default menubar styling.
+- The `story` class on the passage wrapper provides the default passage area styling.
+- The `{include}` macro re-renders when referenced variables change, making it ideal for dynamic panels and status displays.
+- You have full control over the HTML structure, so you can use CSS Grid, Flexbox, or any layout technique.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -35,6 +35,47 @@ More content.
 
 Widget names are case-insensitive: `{statusbar}`, `{StatusBar}`, and `{STATUSBAR}` all work.
 
+## Arguments
+
+Widgets can accept arguments, making them more flexible. Declare parameter names after the widget name using `$` or `_` prefixed variables:
+
+```
+:: StoryInit
+{widget "StatLine" $label $value $max}
+  **{$label}:** {$value} / {$max}
+{/widget}
+```
+
+Pass arguments as comma-separated expressions when invoking the widget:
+
+```
+:: Start
+{StatLine "Health", $health, $max_health}
+{StatLine "Mana", $mana, $max_mana}
+{StatLine "XP", $xp, $xp_needed}
+```
+
+Arguments are evaluated as expressions, so you can pass variables, literals, or computed values:
+
+```
+{StatLine "Damage", $strength * 2, 100}
+```
+
+Parameters are scoped to the widget body — they don't affect story variables with the same name. If fewer arguments are passed than parameters declared, the extra parameters are `undefined`.
+
+### Temporary Parameters
+
+Use `_` prefixed parameters for temporary variables that should not conflict with story variables:
+
+```
+{widget "Badge" _text _color}
+  <span class="badge" style="color: {_color}">{_text}</span>
+{/widget}
+
+{Badge "NEW", "green"}
+{Badge "SALE", "red"}
+```
+
 ## How Widgets Work
 
 When you define a widget, its body is stored as an AST (parsed content). When you invoke it, that AST is rendered in place. This means:
@@ -42,8 +83,11 @@ When you define a widget, its body is stored as an AST (parsed content). When yo
 - Widgets see the current values of all variables at the time they are rendered
 - Widgets re-render when variables they reference change
 - Widgets can contain any markup: links, macros, HTML, other widgets
+- Arguments are evaluated at invocation time and scoped to the widget body
 
 ## Example
+
+A simple widget without arguments:
 
 ```
 :: StoryInit
@@ -68,4 +112,21 @@ HP: {HealthBar}
 
 {set $health = $health - 20}
 A trap! You take damage.
+```
+
+A parameterized widget for reusable UI:
+
+```
+:: StoryInit
+{widget "ResourceBar" $label $current $maximum}
+  <div class="resource-bar">
+    <span class="resource-label">{$label}</span>
+    {meter $current $maximum}
+  </div>
+{/widget}
+
+:: Start
+{ResourceBar "HP", $health, $max_health}
+{ResourceBar "MP", $mana, $max_mana}
+{ResourceBar "Stamina", $stamina, $max_stamina}
 ```

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from 'preact/hooks';
 import { useStoryStore } from '../store';
-import { Passage } from './Passage';
 import { StoryInterface } from './StoryInterface';
 
 export function App() {
-  const currentPassage = useStoryStore((s) => s.currentPassage);
   const storyData = useStoryStore((s) => s.storyData);
+  const currentPassage = useStoryStore((s) => s.currentPassage);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -25,29 +24,5 @@ export function App() {
     return <div class="loading">Loading...</div>;
   }
 
-  const passage = storyData.passages.get(currentPassage);
-  if (!passage) {
-    return (
-      <div class="error">
-        Error: Passage &ldquo;{currentPassage}&rdquo; not found.
-      </div>
-    );
-  }
-
-  return (
-    <>
-      <header class="story-menubar">
-        <StoryInterface />
-      </header>
-      <div
-        id="story"
-        class="story"
-      >
-        <Passage
-          passage={passage}
-          key={currentPassage}
-        />
-      </div>
-    </>
-  );
+  return <StoryInterface />;
 }

--- a/src/components/StoryInterface.tsx
+++ b/src/components/StoryInterface.tsx
@@ -1,11 +1,10 @@
-import { useMemo } from 'preact/hooks';
 import { useStoryStore } from '../store';
 import { tokenize } from '../markup/tokenizer';
 import { buildAST } from '../markup/ast';
 import { renderNodes } from '../markup/render';
 
 const DEFAULT_MARKUP =
-  '{story-title}{back}{forward}{restart}{quicksave}{quickload}{saves}{settings}';
+  '<header class="story-menubar">{story-title}{back}{forward}{restart}{quicksave}{quickload}{saves}{settings}</header>\n{passage}';
 
 export function StoryInterface() {
   const storyData = useStoryStore((s) => s.storyData);
@@ -14,19 +13,15 @@ export function StoryInterface() {
   const markup =
     overridePassage !== undefined ? overridePassage.content : DEFAULT_MARKUP;
 
-  const content = useMemo(() => {
-    try {
-      const tokens = tokenize(markup);
-      const ast = buildAST(tokens);
-      return renderNodes(ast);
-    } catch (err) {
-      return (
-        <span class="error">
-          Error in StoryInterface: {(err as Error).message}
-        </span>
-      );
-    }
-  }, [markup]);
-
-  return <>{content}</>;
+  try {
+    const tokens = tokenize(markup);
+    const ast = buildAST(tokens);
+    return <>{renderNodes(ast)}</>;
+  } catch (err) {
+    return (
+      <span class="error">
+        Error in StoryInterface: {(err as Error).message}
+      </span>
+    );
+  }
 }

--- a/src/components/macros/PassageDisplay.tsx
+++ b/src/components/macros/PassageDisplay.tsx
@@ -1,0 +1,33 @@
+import { useStoryStore } from '../../store';
+import { Passage } from '../Passage';
+
+interface PassageDisplayProps {
+  className?: string;
+  id?: string;
+}
+
+export function PassageDisplay({ className, id }: PassageDisplayProps) {
+  const currentPassage = useStoryStore((s) => s.currentPassage);
+  const storyData = useStoryStore((s) => s.storyData);
+
+  const passage = storyData?.passages.get(currentPassage);
+  if (!passage) {
+    return (
+      <div class="error">
+        Error: Passage &ldquo;{currentPassage}&rdquo; not found.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      id={id ?? 'story'}
+      class={className ?? 'story'}
+    >
+      <Passage
+        passage={passage}
+        key={currentPassage}
+      />
+    </div>
+  );
+}

--- a/src/components/macros/Widget.tsx
+++ b/src/components/macros/Widget.tsx
@@ -7,11 +7,23 @@ interface WidgetProps {
   children: ASTNode[];
 }
 
+/**
+ * Parse widget definition args: "WidgetName" or "WidgetName" $param1 $param2
+ */
+function parseWidgetDef(rawArgs: string): { name: string; params: string[] } {
+  const tokens = rawArgs.trim().split(/\s+/);
+  const name = tokens[0]!.replace(/["']/g, '');
+  const params = tokens
+    .slice(1)
+    .filter((t) => t.startsWith('$') || t.startsWith('_'));
+  return { name, params };
+}
+
 export function Widget({ rawArgs, children }: WidgetProps) {
-  const name = rawArgs.trim().replace(/["']/g, '');
+  const { name, params } = parseWidgetDef(rawArgs);
 
   useLayoutEffect(() => {
-    registerWidget(name, children);
+    registerWidget(name, children, params);
   }, []);
 
   return null;

--- a/src/components/macros/WidgetInvocation.tsx
+++ b/src/components/macros/WidgetInvocation.tsx
@@ -1,0 +1,97 @@
+import { useContext } from 'preact/hooks';
+import { LocalsContext, renderNodes } from '../../markup/render';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
+import { evaluate } from '../../expression';
+import type { ASTNode } from '../../markup/ast';
+
+interface WidgetInvocationProps {
+  body: ASTNode[];
+  params: string[];
+  rawArgs?: string;
+}
+
+/**
+ * Split rawArgs by commas, respecting parentheses, brackets, braces, and strings.
+ */
+function splitArgs(raw: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i]!;
+
+    if (inString) {
+      current += ch;
+      if (ch === inString && raw[i - 1] !== '\\') inString = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inString = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth++;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ')' || ch === ']' || ch === '}') {
+      depth--;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ',' && depth === 0) {
+      args.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+
+  const last = current.trim();
+  if (last) args.push(last);
+  return args;
+}
+
+export function WidgetInvocation({
+  body,
+  params,
+  rawArgs,
+}: WidgetInvocationProps) {
+  const parentLocals = useContext(LocalsContext);
+  const [mergedVars, mergedTemps] = useMergedLocals();
+
+  if (params.length === 0 || !rawArgs) {
+    return <>{renderNodes(body)}</>;
+  }
+
+  const argExprs = splitArgs(rawArgs);
+  const locals: Record<string, unknown> = { ...parentLocals };
+
+  for (let i = 0; i < params.length; i++) {
+    const param = params[i]!;
+    const expr = argExprs[i];
+    let value: unknown;
+    if (expr !== undefined) {
+      try {
+        value = evaluate(expr, mergedVars, mergedTemps);
+      } catch {
+        value = undefined;
+      }
+    }
+    locals[param] = value;
+  }
+
+  return (
+    <LocalsContext.Provider value={locals}>
+      {renderNodes(body)}
+    </LocalsContext.Provider>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,8 +95,12 @@ function boot() {
       const widgetAST = buildAST(widgetTokens);
       for (const node of widgetAST) {
         if (node.type === 'macro' && node.name === 'widget' && node.rawArgs) {
-          const widgetName = node.rawArgs.trim().replace(/["']/g, '');
-          registerWidget(widgetName, node.children as ASTNode[]);
+          const tokens2 = node.rawArgs.trim().split(/\s+/);
+          const widgetName = tokens2[0]!.replace(/["']/g, '');
+          const params = tokens2
+            .slice(1)
+            .filter((t) => t.startsWith('$') || t.startsWith('_'));
+          registerWidget(widgetName, node.children as ASTNode[], params);
         }
       }
     }
@@ -110,6 +114,18 @@ function boot() {
       resetIdCounters();
     }
   });
+
+  // Warn if StoryInterface passage exists but doesn't contain {passage}
+  const storyInterfacePassage = storyData.passages.get('StoryInterface');
+  if (
+    storyInterfacePassage &&
+    !storyInterfacePassage.content.includes('{passage}')
+  ) {
+    console.warn(
+      'spindle: StoryInterface passage does not contain {passage}. ' +
+        'The current passage will not be displayed.',
+    );
+  }
 
   const root = document.getElementById('root');
   if (!root) {

--- a/src/markup/render.tsx
+++ b/src/markup/render.tsx
@@ -32,8 +32,10 @@ import { Repeat } from '../components/macros/Repeat';
 import { Stop } from '../components/macros/Stop';
 import { Type } from '../components/macros/Type';
 import { Widget } from '../components/macros/Widget';
+import { WidgetInvocation } from '../components/macros/WidgetInvocation';
 import { Computed } from '../components/macros/Computed';
 import { Meter } from '../components/macros/Meter';
+import { PassageDisplay } from '../components/macros/PassageDisplay';
 import { getWidget } from '../widgets/widget-registry';
 import { getMacro } from '../registry';
 import { markdownToHtml } from './markdown';
@@ -127,6 +129,15 @@ function renderMacro(node: MacroNode, key: number) {
         <Meter
           key={key}
           rawArgs={node.rawArgs}
+          className={node.className}
+          id={node.id}
+        />
+      );
+
+    case 'passage':
+      return (
+        <PassageDisplay
+          key={key}
           className={node.className}
           id={node.id}
         />
@@ -415,9 +426,16 @@ function renderMacro(node: MacroNode, key: number) {
 
     default: {
       // Check widget registry for user-defined widgets
-      const widgetAST = getWidget(node.name);
-      if (widgetAST) {
-        return <>{renderNodes(widgetAST)}</>;
+      const widget = getWidget(node.name);
+      if (widget) {
+        return (
+          <WidgetInvocation
+            key={key}
+            body={widget.body}
+            params={widget.params}
+            rawArgs={node.rawArgs}
+          />
+        );
       }
 
       // Check component registry for custom macros

--- a/src/widgets/widget-registry.ts
+++ b/src/widgets/widget-registry.ts
@@ -1,12 +1,21 @@
 import type { ASTNode } from '../markup/ast';
 
-const widgets = new Map<string, ASTNode[]>();
-
-export function registerWidget(name: string, bodyAST: ASTNode[]): void {
-  widgets.set(name.toLowerCase(), bodyAST);
+interface WidgetEntry {
+  body: ASTNode[];
+  params: string[];
 }
 
-export function getWidget(name: string): ASTNode[] | undefined {
+const widgets = new Map<string, WidgetEntry>();
+
+export function registerWidget(
+  name: string,
+  bodyAST: ASTNode[],
+  params: string[],
+): void {
+  widgets.set(name.toLowerCase(), { body: bodyAST, params });
+}
+
+export function getWidget(name: string): WidgetEntry | undefined {
   return widgets.get(name.toLowerCase());
 }
 

--- a/test/unit/widget-registry.test.ts
+++ b/test/unit/widget-registry.test.ts
@@ -13,8 +13,10 @@ describe('widget-registry', () => {
 
   it('registers and retrieves a widget by name', () => {
     const body: ASTNode[] = [{ type: 'text', value: 'Hello from widget' }];
-    registerWidget('greeting', body);
-    expect(getWidget('greeting')).toBe(body);
+    registerWidget('greeting', body, []);
+    const widget = getWidget('greeting');
+    expect(widget?.body).toBe(body);
+    expect(widget?.params).toEqual([]);
   });
 
   it('returns undefined for unregistered widget', () => {
@@ -23,22 +25,29 @@ describe('widget-registry', () => {
 
   it('is case-insensitive', () => {
     const body: ASTNode[] = [{ type: 'text', value: 'test' }];
-    registerWidget('MyWidget', body);
-    expect(getWidget('mywidget')).toBe(body);
-    expect(getWidget('MYWIDGET')).toBe(body);
+    registerWidget('MyWidget', body, []);
+    expect(getWidget('mywidget')?.body).toBe(body);
+    expect(getWidget('MYWIDGET')?.body).toBe(body);
   });
 
   it('overwrites a widget with the same name', () => {
     const body1: ASTNode[] = [{ type: 'text', value: 'v1' }];
     const body2: ASTNode[] = [{ type: 'text', value: 'v2' }];
-    registerWidget('w', body1);
-    registerWidget('w', body2);
-    expect(getWidget('w')).toBe(body2);
+    registerWidget('w', body1, []);
+    registerWidget('w', body2, []);
+    expect(getWidget('w')?.body).toBe(body2);
+  });
+
+  it('stores parameter names', () => {
+    const body: ASTNode[] = [{ type: 'text', value: 'test' }];
+    registerWidget('greet', body, ['$name', '$age']);
+    const widget = getWidget('greet');
+    expect(widget?.params).toEqual(['$name', '$age']);
   });
 
   it('clearWidgets removes all widgets', () => {
-    registerWidget('a', [{ type: 'text', value: 'A' }]);
-    registerWidget('b', [{ type: 'text', value: 'B' }]);
+    registerWidget('a', [{ type: 'text', value: 'A' }], []);
+    registerWidget('b', [{ type: 'text', value: 'B' }], []);
     clearWidgets();
     expect(getWidget('a')).toBeUndefined();
     expect(getWidget('b')).toBeUndefined();


### PR DESCRIPTION
## Summary

- **StoryInterface rework**: The `StoryInterface` passage now controls the entire page layout (not just the menubar). The default layout is defined as markup internally, so there's a single code path whether or not a custom StoryInterface passage exists.
- **`{passage}` macro**: New macro that renders the current passage display area. Authors place it within their StoryInterface markup to control where passages appear.
- **Widget arguments**: Widgets can now accept parameters (`{widget "Name" $param1 $param2}`) and be invoked with arguments (`{Name "arg1", $var}`). Arguments are scoped via `LocalsContext`.
- **Docs**: Added dedicated StoryInterface documentation page, expandable sidebar navigation for Macros/Special Passages/Widgets, and updated widget docs with argument examples.

## Test plan

- [ ] No StoryInterface passage: default layout works exactly as before (menubar + passage)
- [ ] With StoryInterface passage containing `{passage}`: full custom layout renders, navigation works
- [ ] StoryInterface with `{include}`: sidebar/panel passages render and update reactively
- [ ] StoryInterface without `{passage}`: console warning fires
- [ ] Widget without arguments: works as before
- [ ] Widget with arguments: params are scoped, don't leak to story variables
- [ ] All 387 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)