### PR TITLE
feat: add @ locals namespace for block-scoped variables

### DIFF
--- a/dev/story.twee
+++ b/dev/story.twee
@@ -248,8 +248,8 @@ Health: {$player.hp}/{$player.maxHp} —
 
 Inventory ({print $inventory.length} items):
 
-{for $item, $i of $inventory}
-  {print $i + 1}. {$item}
+{for @item, @i of $inventory}
+  {print @i + 1}. {@item}
 {/for}
 
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -27,20 +27,20 @@ Each condition is a JavaScript expression where `$var` references story variable
 Loop over an array.
 
 ```
-{for $item of $inventory}
-  - {$item}
+{for @item of $inventory}
+  - {@item}
 {/for}
 ```
 
 With an index variable:
 
 ```
-{for $item, $i of $items}
-  {print $i + 1}. {$item}
+{for @item, @i of $items}
+  {print @i + 1}. {@item}
 {/for}
 ```
 
-The loop variables (`$item`, `$i`) are local to the loop body and do not affect story variables.
+The loop variables (`@item`, `@i`) use the `@` prefix and are block-scoped to the loop body. They do not affect `$` story variables or `_` temporary variables.
 
 ### `{switch}` / `{case}` / `{default}`
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,6 +1,6 @@
 # Variables
 
-Spindle has two kinds of variables: **story variables** that persist across passages and **temporary variables** that reset on each navigation.
+Spindle has three kinds of variables: **story variables** that persist across passages, **temporary variables** that reset on each navigation, and **local variables** that are scoped to a block (for-loop or widget body).
 
 ## Story Variables
 
@@ -106,7 +106,7 @@ Then use methods and getters in your passages:
 
 ## Expressions
 
-Anywhere Spindle expects a value (conditions in `{if}`, values in `{set}`, arguments to `{print}`), you write JavaScript expressions with `$var` and `_var` placeholders:
+Anywhere Spindle expects a value (conditions in `{if}`, values in `{set}`, arguments to `{print}`), you write JavaScript expressions with `$var`, `_var`, and `@var` placeholders:
 
 ```
 {if $health > 0 && $character.alive}
@@ -120,6 +120,7 @@ Before evaluation, the expression system transforms:
 
 - `$varName` into a reference to the story variable `varName`
 - `_tempName` into a reference to the temporary variable `tempName`
+- `@localName` into a reference to the block-scoped local `localName`
 
 Standard JavaScript operators and built-in functions (`Math`, `Array` methods, string methods) all work.
 
@@ -172,14 +173,51 @@ Access passage metadata in expressions:
 
 **Rendered** is a superset of visited — it also counts passages rendered inline via `{include}`.
 
+## Local Variables
+
+Local variables start with `@` and are block-scoped to for-loops and widget bodies. They do not conflict with `$` story variables or `_` temporary variables.
+
 ### For-loop locals
 
-Inside a `{for}` loop, the loop variables are available as locals and do not conflict with story variables of the same name:
+Inside a `{for}` loop, the loop variables use `@` prefix and are scoped to the loop body:
 
 ```
-{for $item, $i of $inventory}
-  {print $i + 1}. {$item}
+{for @item, @i of $inventory}
+  {print @i + 1}. {@item}
 {/for}
 ```
 
-Here `$item` and `$i` are scoped to the loop body.
+### Widget locals
+
+Widget parameters also use `@` prefix:
+
+```
+{widget "StatusBar" @label @value @max}
+  <div class="bar">{@label}: {@value}/{@max}</div>
+{/widget}
+
+{StatusBar "HP", $health, $maxHealth}
+```
+
+### Mutating locals
+
+Locals can be modified within their scope using `{set}`:
+
+```
+{for @item, @i of $inventory}
+  {set @label = @item + " (" + (@i + 1) + ")"}
+  {@label}
+{/for}
+```
+
+### Nesting
+
+Inner scopes inherit parent locals. Each scope maintains its own bindings:
+
+```
+{for @item of $items}
+  {for @sub of @item.children}
+    {@item.name}: {@sub}
+  {/for}
+{/for}
+```

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -37,12 +37,12 @@ Widget names are case-insensitive: `{statusbar}`, `{StatusBar}`, and `{STATUSBAR
 
 ## Arguments
 
-Widgets can accept arguments, making them more flexible. Declare parameter names after the widget name using `$` or `_` prefixed variables:
+Widgets can accept arguments, making them more flexible. Declare parameter names after the widget name using `@` prefixed local variables:
 
 ```
 :: StoryInit
-{widget "StatLine" $label $value $max}
-  **{$label}:** {$value} / {$max}
+{widget "StatLine" @label @value @max}
+  **{@label}:** {@value} / {@max}
 {/widget}
 ```
 
@@ -61,20 +61,7 @@ Arguments are evaluated as expressions, so you can pass variables, literals, or 
 {StatLine "Damage", $strength * 2, 100}
 ```
 
-Parameters are scoped to the widget body — they don't affect story variables with the same name. If fewer arguments are passed than parameters declared, the extra parameters are `undefined`.
-
-### Temporary Parameters
-
-Use `_` prefixed parameters for temporary variables that should not conflict with story variables:
-
-```
-{widget "Badge" _text _color}
-  <span class="badge" style="color: {_color}">{_text}</span>
-{/widget}
-
-{Badge "NEW", "green"}
-{Badge "SALE", "red"}
-```
+Parameters are block-scoped to the widget body using the `@` namespace — they never conflict with `$` story variables or `_` temporary variables. If fewer arguments are passed than parameters declared, the extra parameters are `undefined`.
 
 ## How Widgets Work
 
@@ -118,10 +105,10 @@ A parameterized widget for reusable UI:
 
 ```
 :: StoryInit
-{widget "ResourceBar" $label $current $maximum}
+{widget "ResourceBar" @label @current @maximum}
   <div class="resource-bar">
-    <span class="resource-label">{$label}</span>
-    {meter $current $maximum}
+    <span class="resource-label">{@label}</span>
+    {meter @current @maximum}
   </div>
 {/widget}
 

--- a/src/components/macros/Button.tsx
+++ b/src/components/macros/Button.tsx
@@ -1,9 +1,11 @@
+import { useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import { execute } from '../../expression';
-import { renderInlineNodes } from '../../markup/render';
+import { renderInlineNodes, LocalsContext } from '../../markup/render';
 import { deepClone } from '../../class-registry';
 import { collectText } from '../../utils/extract-text';
 import { useAction } from '../../hooks/use-action';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 import type { ASTNode } from '../../markup/ast';
 
 interface ButtonProps {
@@ -14,13 +16,17 @@ interface ButtonProps {
 }
 
 export function Button({ rawArgs, children, className, id }: ButtonProps) {
+  const scope = useContext(LocalsContext);
+  const [, , mergedLocals] = useMergedLocals();
+
   const handleClick = () => {
     const state = useStoryStore.getState();
     const vars = deepClone(state.variables);
     const temps = deepClone(state.temporary);
+    const localsClone = { ...mergedLocals };
 
     try {
-      execute(rawArgs, vars, temps);
+      execute(rawArgs, vars, temps, localsClone);
     } catch (err) {
       console.error(`spindle: Error in {button ${rawArgs}}:`, err);
       return;
@@ -34,6 +40,11 @@ export function Button({ rawArgs, children, className, id }: ButtonProps) {
     for (const key of Object.keys(temps)) {
       if (temps[key] !== state.temporary[key]) {
         state.setTemporary(key, temps[key]);
+      }
+    }
+    for (const key of Object.keys(localsClone)) {
+      if (localsClone[key] !== mergedLocals[key]) {
+        scope.update(`@${key}`, localsClone[key]);
       }
     }
   };

--- a/src/components/macros/Computed.tsx
+++ b/src/components/macros/Computed.tsx
@@ -59,7 +59,7 @@ function valuesEqual(a: unknown, b: unknown): boolean {
 }
 
 export function Computed({ rawArgs }: ComputedProps) {
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   let target: string;
   let expr: string;
@@ -84,7 +84,7 @@ export function Computed({ rawArgs }: ComputedProps) {
 
     let newValue: unknown;
     try {
-      newValue = evaluate(expr, mergedVars, mergedTemps);
+      newValue = evaluate(expr, mergedVars, mergedTemps, mergedLocals);
     } catch (err) {
       console.error(`spindle: Error in {computed ${rawArgs}}:`, err);
       return;

--- a/src/components/macros/Do.tsx
+++ b/src/components/macros/Do.tsx
@@ -1,8 +1,10 @@
-import { useLayoutEffect } from 'preact/hooks';
+import { useLayoutEffect, useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import { execute } from '../../expression';
 import type { ASTNode } from '../../markup/ast';
 import { deepClone } from '../../class-registry';
+import { LocalsContext } from '../../markup/render';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 
 interface DoProps {
   children: ASTNode[];
@@ -17,14 +19,17 @@ function collectText(nodes: ASTNode[]): string {
 
 export function Do({ children }: DoProps) {
   const code = collectText(children);
+  const scope = useContext(LocalsContext);
+  const [, , mergedLocals] = useMergedLocals();
 
   useLayoutEffect(() => {
     const state = useStoryStore.getState();
     const vars = deepClone(state.variables);
     const temps = deepClone(state.temporary);
+    const localsClone = { ...mergedLocals };
 
     try {
-      execute(code, vars, temps);
+      execute(code, vars, temps, localsClone);
     } catch (err) {
       console.error(`spindle: Error in {do}:`, err);
       return;
@@ -39,6 +44,11 @@ export function Do({ children }: DoProps) {
     for (const key of Object.keys(temps)) {
       if (temps[key] !== state.temporary[key]) {
         state.setTemporary(key, temps[key]);
+      }
+    }
+    for (const key of Object.keys(localsClone)) {
+      if (localsClone[key] !== mergedLocals[key]) {
+        scope.update(`@${key}`, localsClone[key]);
       }
     }
   }, []);

--- a/src/components/macros/For.tsx
+++ b/src/components/macros/For.tsx
@@ -1,6 +1,7 @@
-import { useContext } from 'preact/hooks';
+import { useContext, useState, useCallback } from 'preact/hooks';
 import { evaluate } from '../../expression';
 import { LocalsContext, renderNodes } from '../../markup/render';
+import type { LocalsScope } from '../../markup/render';
 import { useMergedLocals } from '../../hooks/use-merged-locals';
 import type { ASTNode } from '../../markup/ast';
 
@@ -12,7 +13,7 @@ interface ForProps {
 }
 
 /**
- * Parse for-loop args: "$item, $i of $list" or "$item of $list"
+ * Parse for-loop args: "@item, @i of $list" or "@item of $list"
  */
 function parseForArgs(rawArgs: string): {
   itemVar: string;
@@ -31,12 +32,51 @@ function parseForArgs(rawArgs: string): {
   const itemVar = vars[0]!;
   const indexVar = vars.length > 1 ? vars[1]! : null;
 
+  if (!itemVar.startsWith('@')) {
+    throw new Error(`{for} loop variable must use @ prefix: got "${itemVar}"`);
+  }
+  if (indexVar && !indexVar.startsWith('@')) {
+    throw new Error(
+      `{for} index variable must use @ prefix: got "${indexVar}"`,
+    );
+  }
+
   return { itemVar, indexVar, listExpr };
 }
 
+function ForIteration({
+  parentValues,
+  ownKeys,
+  initialValues,
+  children,
+}: {
+  parentValues: Record<string, unknown>;
+  ownKeys: Record<string, unknown>;
+  initialValues: Record<string, unknown>;
+  children: ASTNode[];
+}) {
+  const [localState, setLocalState] = useState<Record<string, unknown>>(() => ({
+    ...parentValues,
+    ...ownKeys,
+    ...initialValues,
+  }));
+
+  const update = useCallback((key: string, value: unknown) => {
+    setLocalState((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const scope: LocalsScope = { values: localState, update };
+
+  return (
+    <LocalsContext.Provider value={scope}>
+      {renderNodes(children)}
+    </LocalsContext.Provider>
+  );
+}
+
 export function For({ rawArgs, children, className, id }: ForProps) {
-  const parentLocals = useContext(LocalsContext);
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const parentScope = useContext(LocalsContext);
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   let parsed: ReturnType<typeof parseForArgs>;
   try {
@@ -56,7 +96,7 @@ export function For({ rawArgs, children, className, id }: ForProps) {
 
   let list: unknown[];
   try {
-    const result = evaluate(listExpr, mergedVars, mergedTemps);
+    const result = evaluate(listExpr, mergedVars, mergedTemps, mergedLocals);
     if (!Array.isArray(result)) {
       return (
         <span class="error">
@@ -77,19 +117,19 @@ export function For({ rawArgs, children, className, id }: ForProps) {
   }
 
   const content = list.map((item, i) => {
-    const locals = {
-      ...parentLocals,
+    const ownKeys: Record<string, unknown> = {
       [itemVar]: item,
       ...(indexVar ? { [indexVar]: i } : undefined),
     };
 
     return (
-      <LocalsContext.Provider
+      <ForIteration
         key={i}
-        value={locals}
-      >
-        {renderNodes(children)}
-      </LocalsContext.Provider>
+        parentValues={parentScope.values}
+        ownKeys={ownKeys}
+        initialValues={{}}
+        children={children}
+      />
     );
   });
 

--- a/src/components/macros/Goto.tsx
+++ b/src/components/macros/Goto.tsx
@@ -1,22 +1,24 @@
 import { useLayoutEffect } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import { evaluate } from '../../expression';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 
 interface GotoProps {
   rawArgs: string;
 }
 
 export function Goto({ rawArgs }: GotoProps) {
+  const [variables, temporary, locals] = useMergedLocals();
+
   useLayoutEffect(() => {
-    const state = useStoryStore.getState();
     let passageName: string;
     try {
-      const result = evaluate(rawArgs, state.variables, state.temporary);
+      const result = evaluate(rawArgs, variables, temporary, locals);
       passageName = String(result);
     } catch {
       passageName = rawArgs.replace(/^["']|["']$/g, '');
     }
-    state.navigate(passageName);
+    useStoryStore.getState().navigate(passageName);
   }, []);
 
   return null;

--- a/src/components/macros/If.tsx
+++ b/src/components/macros/If.tsx
@@ -8,7 +8,7 @@ interface IfProps {
 }
 
 export function If({ branches }: IfProps) {
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   function renderBranch(branch: Branch) {
     const children = renderNodes(branch.children);
@@ -31,7 +31,12 @@ export function If({ branches }: IfProps) {
     }
 
     try {
-      const result = evaluate(branch.rawArgs, mergedVars, mergedTemps);
+      const result = evaluate(
+        branch.rawArgs,
+        mergedVars,
+        mergedTemps,
+        mergedLocals,
+      );
       if (result) {
         return renderBranch(branch);
       }

--- a/src/components/macros/Include.tsx
+++ b/src/components/macros/Include.tsx
@@ -3,6 +3,7 @@ import { evaluate } from '../../expression';
 import { tokenize } from '../../markup/tokenizer';
 import { buildAST } from '../../markup/ast';
 import { renderNodes } from '../../markup/render';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 
 interface IncludeProps {
   rawArgs: string;
@@ -12,14 +13,13 @@ interface IncludeProps {
 
 export function Include({ rawArgs, className, id }: IncludeProps) {
   const storyData = useStoryStore((s) => s.storyData);
-  const variables = useStoryStore((s) => s.variables);
-  const temporary = useStoryStore((s) => s.temporary);
+  const [variables, temporary, locals] = useMergedLocals();
 
   if (!storyData) return null;
 
   let passageName: string;
   try {
-    const result = evaluate(rawArgs, variables, temporary);
+    const result = evaluate(rawArgs, variables, temporary, locals);
     passageName = String(result);
   } catch {
     passageName = rawArgs.replace(/^["']|["']$/g, '');

--- a/src/components/macros/MacroLink.tsx
+++ b/src/components/macros/MacroLink.tsx
@@ -1,7 +1,10 @@
+import { useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import { execute } from '../../expression';
 import type { ASTNode } from '../../markup/ast';
 import { deepClone } from '../../class-registry';
+import { LocalsContext } from '../../markup/render';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 
 interface MacroLinkProps {
   rawArgs: string;
@@ -37,23 +40,28 @@ import { useAction } from '../../hooks/use-action';
 /**
  * Execute the children imperatively: walk AST for {set} and {do} macros.
  */
-function executeChildren(children: ASTNode[]) {
+function executeChildren(
+  children: ASTNode[],
+  mergedLocals: Record<string, unknown>,
+  scopeUpdate: (key: string, value: unknown) => void,
+) {
   const state = useStoryStore.getState();
   const vars = deepClone(state.variables);
   const temps = deepClone(state.temporary);
+  const localsClone = { ...mergedLocals };
 
   for (const node of children) {
     if (node.type !== 'macro') continue;
     if (node.name === 'set') {
       try {
-        execute(node.rawArgs, vars, temps);
+        execute(node.rawArgs, vars, temps, localsClone);
       } catch (err) {
         console.error(`spindle: Error in {link} child {set}:`, err);
       }
     } else if (node.name === 'do') {
       const code = collectText(node.children);
       try {
-        execute(code, vars, temps);
+        execute(code, vars, temps, localsClone);
       } catch (err) {
         console.error(`spindle: Error in {link} child {do}:`, err);
       }
@@ -71,6 +79,11 @@ function executeChildren(children: ASTNode[]) {
       state.setTemporary(key, temps[key]);
     }
   }
+  for (const key of Object.keys(localsClone)) {
+    if (localsClone[key] !== mergedLocals[key]) {
+      scopeUpdate(`@${key}`, localsClone[key]);
+    }
+  }
 }
 
 export function MacroLink({
@@ -80,10 +93,12 @@ export function MacroLink({
   id,
 }: MacroLinkProps) {
   const { display, passage } = parseArgs(rawArgs);
+  const scope = useContext(LocalsContext);
+  const [, , mergedLocals] = useMergedLocals();
 
   const handleClick = (e: Event) => {
     e.preventDefault();
-    executeChildren(children);
+    executeChildren(children, mergedLocals, scope.update);
     if (passage) {
       useStoryStore.getState().navigate(passage);
     }
@@ -96,7 +111,7 @@ export function MacroLink({
     label: display,
     target: passage ?? undefined,
     perform: () => {
-      executeChildren(children);
+      executeChildren(children, mergedLocals, scope.update);
       if (passage) {
         useStoryStore.getState().navigate(passage);
       }

--- a/src/components/macros/Meter.tsx
+++ b/src/components/macros/Meter.tsx
@@ -83,12 +83,16 @@ function formatLabel(
 }
 
 export function Meter({ rawArgs, className, id }: MeterProps) {
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   try {
     const { currentExpr, maxExpr, labelMode } = parseArgs(rawArgs);
-    const current = Number(evaluate(currentExpr, mergedVars, mergedTemps));
-    const max = Number(evaluate(maxExpr, mergedVars, mergedTemps));
+    const current = Number(
+      evaluate(currentExpr, mergedVars, mergedTemps, mergedLocals),
+    );
+    const max = Number(
+      evaluate(maxExpr, mergedVars, mergedTemps, mergedLocals),
+    );
     const pct =
       max === 0 ? 0 : Math.max(0, Math.min(100, (current / max) * 100));
     const label = formatLabel(current, max, labelMode);

--- a/src/components/macros/Print.tsx
+++ b/src/components/macros/Print.tsx
@@ -8,10 +8,10 @@ interface PrintProps {
 }
 
 export function Print({ rawArgs, className, id }: PrintProps) {
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   try {
-    const result = evaluate(rawArgs, mergedVars, mergedTemps);
+    const result = evaluate(rawArgs, mergedVars, mergedTemps, mergedLocals);
     const display = result == null ? '' : String(result);
     if (className || id)
       return (

--- a/src/components/macros/Set.tsx
+++ b/src/components/macros/Set.tsx
@@ -1,26 +1,32 @@
-import { useLayoutEffect } from 'preact/hooks';
+import { useLayoutEffect, useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import { execute } from '../../expression';
 import { deepClone } from '../../class-registry';
+import { LocalsContext } from '../../markup/render';
+import { useMergedLocals } from '../../hooks/use-merged-locals';
 
 interface SetProps {
   rawArgs: string;
 }
 
 export function Set({ rawArgs }: SetProps) {
+  const scope = useContext(LocalsContext);
+  const [, , mergedLocals] = useMergedLocals();
+
   useLayoutEffect(() => {
     const state = useStoryStore.getState();
     const vars = deepClone(state.variables);
     const temps = deepClone(state.temporary);
+    const localsClone = { ...mergedLocals };
 
     try {
-      execute(rawArgs, vars, temps);
+      execute(rawArgs, vars, temps, localsClone);
     } catch (err) {
       console.error(`spindle: Error in {set ${rawArgs}}:`, err);
       return;
     }
 
-    // Diff and apply changes
+    // Diff and apply store changes
     for (const key of Object.keys(vars)) {
       if (vars[key] !== state.variables[key]) {
         state.setVariable(key, vars[key]);
@@ -29,6 +35,13 @@ export function Set({ rawArgs }: SetProps) {
     for (const key of Object.keys(temps)) {
       if (temps[key] !== state.temporary[key]) {
         state.setTemporary(key, temps[key]);
+      }
+    }
+
+    // Diff and apply locals changes
+    for (const key of Object.keys(localsClone)) {
+      if (localsClone[key] !== mergedLocals[key]) {
+        scope.update(`@${key}`, localsClone[key]);
       }
     }
   }, []);

--- a/src/components/macros/Switch.tsx
+++ b/src/components/macros/Switch.tsx
@@ -9,11 +9,11 @@ interface SwitchProps {
 }
 
 export function Switch({ rawArgs, branches }: SwitchProps) {
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   let switchValue: unknown;
   try {
-    switchValue = evaluate(rawArgs, mergedVars, mergedTemps);
+    switchValue = evaluate(rawArgs, mergedVars, mergedTemps, mergedLocals);
   } catch (err) {
     return (
       <span
@@ -35,7 +35,12 @@ export function Switch({ rawArgs, branches }: SwitchProps) {
     }
 
     try {
-      const caseValue = evaluate(branch.rawArgs, mergedVars, mergedTemps);
+      const caseValue = evaluate(
+        branch.rawArgs,
+        mergedVars,
+        mergedTemps,
+        mergedLocals,
+      );
       if (switchValue === caseValue) {
         return <>{renderNodes(branch.children)}</>;
       }

--- a/src/components/macros/VarDisplay.tsx
+++ b/src/components/macros/VarDisplay.tsx
@@ -4,22 +4,30 @@ import { LocalsContext } from '../../markup/render';
 
 interface VarDisplayProps {
   name: string;
-  scope: 'variable' | 'temporary';
+  scope: 'variable' | 'temporary' | 'local';
   className?: string;
   id?: string;
 }
 
 export function VarDisplay({ name, scope, className, id }: VarDisplayProps) {
-  const locals = useContext(LocalsContext);
+  const localsScope = useContext(LocalsContext);
   const parts = name.split('.');
   const root = parts[0]!;
   const storeValue = useStoryStore((s) =>
-    scope === 'variable' ? s.variables[root] : s.temporary[root],
+    scope === 'variable'
+      ? s.variables[root]
+      : scope === 'temporary'
+        ? s.temporary[root]
+        : undefined,
   );
 
-  // Locals (from for-loops) override store values
-  const key = scope === 'variable' ? `$${root}` : `_${root}`;
-  let value = key in locals ? locals[key] : storeValue;
+  let value: unknown;
+  if (scope === 'local') {
+    const key = `@${root}`;
+    value = key in localsScope.values ? localsScope.values[key] : undefined;
+  } else {
+    value = storeValue;
+  }
 
   // Resolve dot path (e.g. "character.name" → character['name'])
   for (let i = 1; i < parts.length; i++) {

--- a/src/components/macros/Widget.tsx
+++ b/src/components/macros/Widget.tsx
@@ -13,9 +13,7 @@ interface WidgetProps {
 function parseWidgetDef(rawArgs: string): { name: string; params: string[] } {
   const tokens = rawArgs.trim().split(/\s+/);
   const name = tokens[0]!.replace(/["']/g, '');
-  const params = tokens
-    .slice(1)
-    .filter((t) => t.startsWith('$') || t.startsWith('_'));
+  const params = tokens.slice(1).filter((t) => t.startsWith('@'));
   return { name, params };
 }
 

--- a/src/components/macros/WidgetInvocation.tsx
+++ b/src/components/macros/WidgetInvocation.tsx
@@ -1,5 +1,6 @@
-import { useContext } from 'preact/hooks';
+import { useContext, useState, useCallback } from 'preact/hooks';
 import { LocalsContext, renderNodes } from '../../markup/render';
+import type { LocalsScope } from '../../markup/render';
 import { useMergedLocals } from '../../hooks/use-merged-locals';
 import { evaluate } from '../../expression';
 import type { ASTNode } from '../../markup/ast';
@@ -60,20 +61,47 @@ function splitArgs(raw: string): string[] {
   return args;
 }
 
+function WidgetBody({
+  body,
+  parentValues,
+  ownKeys,
+}: {
+  body: ASTNode[];
+  parentValues: Record<string, unknown>;
+  ownKeys: Record<string, unknown>;
+}) {
+  const [localState, setLocalState] = useState<Record<string, unknown>>(() => ({
+    ...parentValues,
+    ...ownKeys,
+  }));
+
+  const update = useCallback((key: string, value: unknown) => {
+    setLocalState((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const scope: LocalsScope = { values: localState, update };
+
+  return (
+    <LocalsContext.Provider value={scope}>
+      {renderNodes(body)}
+    </LocalsContext.Provider>
+  );
+}
+
 export function WidgetInvocation({
   body,
   params,
   rawArgs,
 }: WidgetInvocationProps) {
-  const parentLocals = useContext(LocalsContext);
-  const [mergedVars, mergedTemps] = useMergedLocals();
+  const parentScope = useContext(LocalsContext);
+  const [mergedVars, mergedTemps, mergedLocals] = useMergedLocals();
 
   if (params.length === 0 || !rawArgs) {
     return <>{renderNodes(body)}</>;
   }
 
   const argExprs = splitArgs(rawArgs);
-  const locals: Record<string, unknown> = { ...parentLocals };
+  const ownKeys: Record<string, unknown> = {};
 
   for (let i = 0; i < params.length; i++) {
     const param = params[i]!;
@@ -81,17 +109,19 @@ export function WidgetInvocation({
     let value: unknown;
     if (expr !== undefined) {
       try {
-        value = evaluate(expr, mergedVars, mergedTemps);
+        value = evaluate(expr, mergedVars, mergedTemps, mergedLocals);
       } catch {
         value = undefined;
       }
     }
-    locals[param] = value;
+    ownKeys[param] = value;
   }
 
   return (
-    <LocalsContext.Provider value={locals}>
-      {renderNodes(body)}
-    </LocalsContext.Provider>
+    <WidgetBody
+      body={body}
+      parentValues={parentScope.values}
+      ownKeys={ownKeys}
+    />
   );
 }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -21,6 +21,7 @@ interface ExpressionFns {
 type CompiledExpression = (
   variables: Record<string, unknown>,
   temporary: Record<string, unknown>,
+  locals: Record<string, unknown>,
   __fns: ExpressionFns,
 ) => unknown;
 
@@ -34,11 +35,13 @@ const fnCache = new Map<string, CompiledExpression>();
  */
 const VAR_RE = /\$(\w+)/g;
 const TEMP_RE = /\b_(\w+)/g;
+const LOCAL_RE = /@(\w+)/g;
 
 function transform(expr: string): string {
   return expr
     .replace(VAR_RE, 'variables["$1"]')
-    .replace(TEMP_RE, 'temporary["$1"]');
+    .replace(TEMP_RE, 'temporary["$1"]')
+    .replace(LOCAL_RE, 'locals["$1"]');
 }
 
 const preamble =
@@ -55,6 +58,7 @@ function getOrCompile(key: string, body: string): CompiledExpression {
   const fn = new Function(
     'variables',
     'temporary',
+    'locals',
     '__fns',
     preamble + body,
   ) as CompiledExpression;
@@ -136,11 +140,12 @@ export function evaluate(
   expr: string,
   variables: Record<string, unknown>,
   temporary: Record<string, unknown>,
+  locals: Record<string, unknown> = {},
 ): unknown {
   const transformed = transform(expr);
   const body = `return (${transformed});`;
   const fn = getOrCompile(body, body);
-  return fn(variables, temporary, buildExpressionFns());
+  return fn(variables, temporary, locals, buildExpressionFns());
 }
 
 /**
@@ -151,15 +156,16 @@ export function execute(
   code: string,
   variables: Record<string, unknown>,
   temporary: Record<string, unknown>,
+  locals: Record<string, unknown> = {},
 ): void {
   const transformed = transform(code);
   const fn = getOrCompile('exec:' + transformed, transformed);
-  fn(variables, temporary, buildExpressionFns());
+  fn(variables, temporary, locals, buildExpressionFns());
 }
 
 /**
  * Convenience: evaluate using store state directly.
  */
 export function evaluateWithState(expr: string, state: StoryState): unknown {
-  return evaluate(expr, state.variables, state.temporary);
+  return evaluate(expr, state.variables, state.temporary, {});
 }

--- a/src/hooks/use-merged-locals.ts
+++ b/src/hooks/use-merged-locals.ts
@@ -3,24 +3,26 @@ import { useStoryStore } from '../store';
 import { LocalsContext } from '../markup/render';
 
 /**
- * Merge store variables/temporary with LocalsContext values.
- * Locals prefixed with `$` go into variables, `_` into temporary.
+ * Return store variables, temporary, and @-prefixed locals from context.
+ * Locals use `@` prefix keys internally; the returned locals dict has
+ * the prefix stripped so it can be passed directly to evaluate/execute.
  */
 export function useMergedLocals(): readonly [
+  Record<string, unknown>,
   Record<string, unknown>,
   Record<string, unknown>,
 ] {
   const variables = useStoryStore((s) => s.variables);
   const temporary = useStoryStore((s) => s.temporary);
-  const locals = useContext(LocalsContext);
+  const scope = useContext(LocalsContext);
 
   return useMemo(() => {
-    const vars = { ...variables };
-    const temps = { ...temporary };
-    for (const [key, val] of Object.entries(locals)) {
-      if (key.startsWith('$')) vars[key.slice(1)] = val;
-      else if (key.startsWith('_')) temps[key.slice(1)] = val;
+    const locals: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(scope.values)) {
+      if (key.startsWith('@')) {
+        locals[key.slice(1)] = val;
+      }
     }
-    return [vars, temps] as const;
-  }, [variables, temporary, locals]);
+    return [variables, temporary, locals] as const;
+  }, [variables, temporary, scope.values]);
 }

--- a/src/markup/ast.ts
+++ b/src/markup/ast.ts
@@ -16,7 +16,7 @@ export interface LinkNode {
 export interface VariableNode {
   type: 'variable';
   name: string;
-  scope: 'variable' | 'temporary';
+  scope: 'variable' | 'temporary' | 'local';
   className?: string;
   id?: string;
 }

--- a/src/markup/render.tsx
+++ b/src/markup/render.tsx
@@ -42,7 +42,17 @@ import { markdownToHtml } from './markdown';
 import { h } from 'preact';
 import type { ASTNode, Branch, MacroNode } from './ast';
 
-export const LocalsContext = createContext<Record<string, unknown>>({});
+export interface LocalsScope {
+  values: Record<string, unknown>;
+  update: (key: string, value: unknown) => void;
+}
+
+const defaultLocalsScope: LocalsScope = {
+  values: {},
+  update: () => {},
+};
+
+export const LocalsContext = createContext<LocalsScope>(defaultLocalsScope);
 
 const EMPTY_BRANCHES: Branch[] = [];
 

--- a/src/markup/tokenizer.ts
+++ b/src/markup/tokenizer.ts
@@ -29,7 +29,7 @@ export interface MacroToken {
 export interface VariableToken {
   type: 'variable';
   name: string;
-  scope: 'variable' | 'temporary';
+  scope: 'variable' | 'temporary' | 'local';
   className?: string;
   id?: string;
   start: number;
@@ -419,6 +419,34 @@ export function tokenize(input: string): Token[] {
           continue;
         }
 
+        if (charAfter === '@') {
+          // {.class#id @local.field}
+          i = afterSelectors + 1;
+          const nameStart = i;
+          while (i < input.length && /[\w.]/.test(input[i]!)) i++;
+          const name = input.slice(nameStart, i);
+
+          if (input[i] === '}') {
+            i++; // skip }
+            const token: VariableToken = {
+              type: 'variable',
+              name,
+              scope: 'local',
+              start,
+              end: i,
+            };
+            if (className) token.className = className;
+            if (id) token.id = id;
+            tokens.push(token);
+            textStart = i;
+            continue;
+          }
+          // Not valid — treat as text
+          i = start + 1;
+          textStart = start;
+          continue;
+        }
+
         if (charAfter !== undefined && /[a-zA-Z]/.test(charAfter)) {
           // {.class#id macroName args}
           i = afterSelectors;
@@ -510,6 +538,32 @@ export function tokenize(input: string): Token[] {
           continue;
         }
         // Not a valid temporary token — treat as text
+        i = start + 1;
+        textStart = start;
+        continue;
+      }
+
+      // {@local.field}
+      if (nextChar === '@') {
+        flushText(i);
+        i += 2;
+        const nameStart = i;
+        while (i < input.length && /[\w.]/.test(input[i]!)) i++;
+        const name = input.slice(nameStart, i);
+
+        if (input[i] === '}') {
+          i++; // skip }
+          tokens.push({
+            type: 'variable',
+            name,
+            scope: 'local',
+            start,
+            end: i,
+          });
+          textStart = i;
+          continue;
+        }
+        // Not a valid local token — treat as text
         i = start + 1;
         textStart = start;
         continue;

--- a/src/story-variables.ts
+++ b/src/story-variables.ts
@@ -14,7 +14,7 @@ export interface VariableSchema extends FieldSchema {
 
 const DECLARATION_RE = /^\$(\w+)\s*=\s*(.+)$/;
 const VAR_REF_RE = /\$(\w+(?:\.\w+)*)/g;
-const FOR_LOCAL_RE = /\{for\s+(\$\w+)(?:\s*,\s*(\$\w+))?\s+of\b/g;
+const FOR_LOCAL_RE = /\{for\s+@(\w+)(?:\s*,\s*@(\w+))?\s+of\b/g;
 
 const VALID_VAR_TYPES = new Set<string>(['number', 'string', 'boolean']);
 
@@ -77,16 +77,16 @@ export function parseStoryVariables(
 
 /**
  * Extract for-loop local variable names from passage content.
- * `{for $item of ...}` → "item"
- * `{for $index, $item of ...}` → "index", "item"
+ * `{for @item of ...}` → "item"
+ * `{for @index, @item of ...}` → "index", "item"
  */
 function extractForLocals(content: string): Set<string> {
   const locals = new Set<string>();
   let match: RegExpExecArray | null;
   FOR_LOCAL_RE.lastIndex = 0;
   while ((match = FOR_LOCAL_RE.exec(content)) !== null) {
-    locals.add(match[1]!.slice(1)); // strip $
-    if (match[2]) locals.add(match[2]!.slice(1));
+    locals.add(match[1]!);
+    if (match[2]) locals.add(match[2]!);
   }
   return locals;
 }

--- a/test/dom/macros.test.tsx
+++ b/test/dom/macros.test.tsx
@@ -120,7 +120,7 @@ describe('macro components', () => {
   describe('{for}', () => {
     it('iterates over an array', () => {
       useStoryStore.getState().setVariable('items', ['a', 'b', 'c']);
-      const el = renderPassage('{for $item of $items}{$item} {/for}');
+      const el = renderPassage('{for @item of $items}{@item} {/for}');
       expect(el.textContent).toContain('a');
       expect(el.textContent).toContain('b');
       expect(el.textContent).toContain('c');
@@ -129,7 +129,7 @@ describe('macro components', () => {
     it('provides index variable', () => {
       useStoryStore.getState().setVariable('items', ['x', 'y']);
       const el = renderPassage(
-        '{for $item, $i of $items}{print $i}: {$item} {/for}',
+        '{for @item, @i of $items}{print @i}: {@item} {/for}',
       );
       expect(el.textContent).toContain('0');
       expect(el.textContent).toContain('x');
@@ -139,7 +139,7 @@ describe('macro components', () => {
 
     it('shows error for non-array', () => {
       useStoryStore.getState().setVariable('x', 42);
-      const el = renderPassage('{for $item of $x}item{/for}');
+      const el = renderPassage('{for @item of $x}item{/for}');
       const error = el.querySelector('.error');
       expect(error).not.toBeNull();
     });

--- a/test/unit/expression.test.ts
+++ b/test/unit/expression.test.ts
@@ -58,6 +58,18 @@ describe('evaluate', () => {
     // Accessing undefined property returns undefined, not an error
     expect(evaluate('$missing', {}, {})).toBeUndefined();
   });
+
+  it('reads @local variables', () => {
+    expect(evaluate('@count', {}, {}, { count: 7 })).toBe(7);
+  });
+
+  it('handles mixed $, _, and @ variables', () => {
+    expect(evaluate('@x + $y + _z', { y: 10 }, { z: 20 }, { x: 5 })).toBe(35);
+  });
+
+  it('returns undefined for missing @local', () => {
+    expect(evaluate('@missing', {}, {}, {})).toBeUndefined();
+  });
 });
 
 describe('execute', () => {
@@ -101,6 +113,25 @@ describe('execute', () => {
 
   it('throws on syntax errors', () => {
     expect(() => execute('$x =', {}, {})).toThrow();
+  });
+
+  it('sets a @local variable', () => {
+    const locals: Record<string, unknown> = {};
+    execute('@count = 42', {}, {}, locals);
+    expect(locals.count).toBe(42);
+  });
+
+  it('modifies existing @local', () => {
+    const locals: Record<string, unknown> = { x: 10 };
+    execute('@x = @x + 5', {}, {}, locals);
+    expect(locals.x).toBe(15);
+  });
+
+  it('can mix @ and $ in assignment', () => {
+    const vars: Record<string, unknown> = { total: 0 };
+    const locals: Record<string, unknown> = { item: 10 };
+    execute('$total = $total + @item', vars, {}, locals);
+    expect(vars.total).toBe(10);
   });
 });
 

--- a/test/unit/story-variables.test.ts
+++ b/test/unit/story-variables.test.ts
@@ -168,21 +168,21 @@ describe('validatePassages', () => {
     );
   });
 
-  it('skips for-loop locals', () => {
+  it('skips for-loop locals (@ syntax not matched by $ validator)', () => {
     const schema = parseStoryVariables('$inventory = []');
     const passages = makePassages(
       ['StoryVariables', '$inventory = []'],
-      ['Start', '{for $item of $inventory}$item{/for}'],
+      ['Start', '{for @item of $inventory}{@item}{/for}'],
     );
     const errors = validatePassages(passages, schema);
     expect(errors).toEqual([]);
   });
 
-  it('skips for-loop locals with index', () => {
+  it('skips for-loop locals with index (@ syntax)', () => {
     const schema = parseStoryVariables('$inventory = []');
     const passages = makePassages(
       ['StoryVariables', '$inventory = []'],
-      ['Start', '{for $i, $item of $inventory}$i: $item{/for}'],
+      ['Start', '{for @i, @item of $inventory}{@i}: {@item}{/for}'],
     );
     const errors = validatePassages(passages, schema);
     expect(errors).toEqual([]);

--- a/test/unit/tokenizer.test.ts
+++ b/test/unit/tokenizer.test.ts
@@ -172,6 +172,64 @@ describe('tokenize', () => {
       const vars = tokens.filter((t) => t.type === 'variable');
       expect(vars).toHaveLength(2);
     });
+
+    it('parses {@local} as local variable token', () => {
+      const tokens = tokenize('{@item}');
+      expect(tokens).toEqual([
+        {
+          type: 'variable',
+          name: 'item',
+          scope: 'local',
+          start: 0,
+          end: 7,
+        },
+      ]);
+    });
+
+    it('parses {@local.field} with dot path', () => {
+      const tokens = tokenize('{@player.name}');
+      expect(tokens).toEqual([
+        {
+          type: 'variable',
+          name: 'player.name',
+          scope: 'local',
+          start: 0,
+          end: 14,
+        },
+      ]);
+    });
+
+    it('handles @ local in text', () => {
+      const tokens = tokenize('Item: {@item} here');
+      expect(tokens).toHaveLength(3);
+      expect(tokens[1]).toEqual({
+        type: 'variable',
+        name: 'item',
+        scope: 'local',
+        start: 6,
+        end: 13,
+      });
+    });
+
+    it('handles mixed $, _, and @ variables', () => {
+      const tokens = tokenize('{$a} {@b} {_c}');
+      const vars = tokens.filter((t) => t.type === 'variable');
+      expect(vars).toHaveLength(3);
+      expect(vars[0]).toMatchObject({ scope: 'variable', name: 'a' });
+      expect(vars[1]).toMatchObject({ scope: 'local', name: 'b' });
+      expect(vars[2]).toMatchObject({ scope: 'temporary', name: 'c' });
+    });
+
+    it('parses {.class @local} with selector prefix', () => {
+      const tokens = tokenize('{.highlight @item}');
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0]).toMatchObject({
+        type: 'variable',
+        name: 'item',
+        scope: 'local',
+        className: 'highlight',
+      });
+    });
   });
 
   describe('macros', () => {


### PR DESCRIPTION
## Summary
- Adds `@var` as a third variable namespace for block-scoped locals (for-loop bindings and widget parameters)
- Clean separation from `$` (story/global) and `_` (temporary/passage-scoped) variables
- For-loop syntax: `{for @item, @i of $list}`, widget syntax: `{widget "Name" @param}`
- Locals are assignable within scope via `{set @x = @x + 1}`
- Nested scopes inherit parent locals; inner mutations stay local

## Test plan
- [x] All 398 existing tests pass (11 new, 4 updated)
- [ ] Build and test manually with for-loops using `@` syntax
- [ ] Verify `$` and `_` variables are unaffected by locals
- [ ] Test nested for-loops and widgets with `@` locals
- [ ] Verify `{set @x = 5}` outside a scope is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)