### PR TITLE
feat: defer state reads in mutating macros

### DIFF
--- a/docs/custom-macros.md
+++ b/docs/custom-macros.md
@@ -66,6 +66,19 @@ function MyMacro({ rawArgs }) {
 
 Use `evaluate()` when your macro takes an expression argument and needs its value — this is how `{print}` and `{if}` work.
 
+### `stripLocalsPrefix()`
+
+For mutating macros that don't need reactive variable subscriptions, use `stripLocalsPrefix()` with `useContext(LocalsContext)` instead of `useMergedLocals()`. This avoids re-renders when unrelated variables change:
+
+```js
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
+
+const scope = useContext(LocalsContext);
+const locals = stripLocalsPrefix(scope.values);
+```
+
+Use this in combination with `executeMutation()`, which reads store variables via `getState()` internally.
+
 ### Direct store access
 
 For reading store state outside the expression engine (e.g. checking passage data or history), access the Zustand store directly:
@@ -88,14 +101,14 @@ If your macro needs to change variables (like `{set}` or `{button}`), use `execu
 
 ```js
 import { executeMutation } from '../../execute-mutation';
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 
 function MyButton({ rawArgs, children }) {
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   const handleClick = () => {
     try {
-      executeMutation(rawArgs, mergedLocals, scope.update);
+      executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
     } catch (err) {
       console.error('MyButton error:', err);
     }
@@ -104,6 +117,8 @@ function MyButton({ rawArgs, children }) {
   return <button onClick={handleClick}>{children}</button>;
 }
 ```
+
+> **Why not `useMergedLocals()`?** Mutating macros don't need to subscribe to store variables reactively — `executeMutation()` reads the latest state via `getState()` internally. Using `stripLocalsPrefix()` with `useContext(LocalsContext)` avoids unnecessary re-renders.
 
 ### Why clone-diff-apply?
 
@@ -134,11 +149,10 @@ Macros like `{set}` and `{print}` execute during the Preact render pass. Their e
 function MySetup({ rawArgs }) {
   const ran = useRef(false);
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   if (!ran.current) {
     ran.current = true;
-    executeMutation(rawArgs, mergedLocals, scope.update);
+    executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
   }
 
   return null;
@@ -152,10 +166,9 @@ Macros like `{do}` run in a `useLayoutEffect` — after the component mounts but
 ```js
 function MyEffect({ rawArgs }) {
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   useLayoutEffect(() => {
-    executeMutation(rawArgs, mergedLocals, scope.update);
+    executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
   }, []);
 
   return null;
@@ -168,7 +181,7 @@ Macros like `{button}` and `{link}` run code in response to clicks. Wrap `execut
 
 ```js
 const handleClick = () => {
-  executeMutation(rawArgs, mergedLocals, scope.update);
+  executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
 };
 return <button onClick={handleClick}>{children}</button>;
 ```
@@ -215,12 +228,11 @@ A `{confirm}` macro that shows a confirmation dialog before executing code:
 {do}
   Story.registerMacro("confirm", (props) => {
     const scope = useContext(LocalsContext);
-    const [, , mergedLocals] = useMergedLocals();
 
     const handleClick = () => {
       if (window.confirm("Are you sure?")) {
         try {
-          executeMutation(props.rawArgs, mergedLocals, scope.update);
+          executeMutation(props.rawArgs, stripLocalsPrefix(scope.values), scope.update);
         } catch (err) {
           console.error("confirm error:", err);
         }

--- a/src/components/macros/Button.tsx
+++ b/src/components/macros/Button.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'preact/hooks';
 import { renderInlineNodes, LocalsContext } from '../../markup/render';
 import { collectText } from '../../utils/extract-text';
 import { useAction } from '../../hooks/use-action';
-import { useMergedLocals } from '../../hooks/use-merged-locals';
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { useInterpolate } from '../../hooks/use-interpolate';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
@@ -20,11 +20,10 @@ export function Button({ rawArgs, children, className, id }: ButtonProps) {
   className = resolve(className);
   id = resolve(id);
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   const handleClick = () => {
     try {
-      executeMutation(rawArgs, mergedLocals, scope.update);
+      executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
     } catch (err) {
       console.error(
         `spindle: Error in {button ${rawArgs}}${currentSourceLocation()}:`,

--- a/src/components/macros/Do.tsx
+++ b/src/components/macros/Do.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useContext } from 'preact/hooks';
 import type { ASTNode } from '../../markup/ast';
 import { LocalsContext } from '../../markup/render';
-import { useMergedLocals } from '../../hooks/use-merged-locals';
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
 
@@ -19,11 +19,10 @@ function collectText(nodes: ASTNode[]): string {
 export function Do({ children }: DoProps) {
   const code = collectText(children);
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   useLayoutEffect(() => {
     try {
-      executeMutation(code, mergedLocals, scope.update);
+      executeMutation(code, stripLocalsPrefix(scope.values), scope.update);
     } catch (err) {
       console.error(`spindle: Error in {do}${currentSourceLocation()}:`, err);
     }

--- a/src/components/macros/MacroLink.tsx
+++ b/src/components/macros/MacroLink.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import type { ASTNode } from '../../markup/ast';
 import { LocalsContext } from '../../markup/render';
-import { useMergedLocals } from '../../hooks/use-merged-locals';
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { useInterpolate } from '../../hooks/use-interpolate';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
@@ -82,11 +82,10 @@ export function MacroLink({
   id = resolve(id);
   const { display, passage } = parseArgs(rawArgs);
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
 
   const handleClick = (e: Event) => {
     e.preventDefault();
-    executeChildren(children, mergedLocals, scope.update);
+    executeChildren(children, stripLocalsPrefix(scope.values), scope.update);
     if (passage) {
       useStoryStore.getState().navigate(passage);
     }
@@ -99,7 +98,7 @@ export function MacroLink({
     label: display,
     target: passage ?? undefined,
     perform: () => {
-      executeChildren(children, mergedLocals, scope.update);
+      executeChildren(children, stripLocalsPrefix(scope.values), scope.update);
       if (passage) {
         useStoryStore.getState().navigate(passage);
       }

--- a/src/components/macros/Set.tsx
+++ b/src/components/macros/Set.tsx
@@ -1,6 +1,6 @@
 import { useRef, useContext } from 'preact/hooks';
 import { LocalsContext } from '../../markup/render';
-import { useMergedLocals } from '../../hooks/use-merged-locals';
+import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
 
@@ -10,14 +10,13 @@ interface SetProps {
 
 export function Set({ rawArgs }: SetProps) {
   const scope = useContext(LocalsContext);
-  const [, , mergedLocals] = useMergedLocals();
   const ran = useRef(false);
 
   if (!ran.current) {
     ran.current = true;
 
     try {
-      executeMutation(rawArgs, mergedLocals, scope.update);
+      executeMutation(rawArgs, stripLocalsPrefix(scope.values), scope.update);
     } catch (err) {
       console.error(
         `spindle: Error in {set ${rawArgs}}${currentSourceLocation()}:`,

--- a/src/hooks/use-merged-locals.ts
+++ b/src/hooks/use-merged-locals.ts
@@ -3,6 +3,22 @@ import { useStoryStore } from '../store';
 import { LocalsContext } from '../markup/render';
 
 /**
+ * Strip `@` prefix from locals scope values so they can be passed
+ * directly to evaluate/execute.
+ */
+export function stripLocalsPrefix(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const locals: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(values)) {
+    if (key.startsWith('@')) {
+      locals[key.slice(1)] = val;
+    }
+  }
+  return locals;
+}
+
+/**
  * Return store variables, temporary, and @-prefixed locals from context.
  * Locals use `@` prefix keys internally; the returned locals dict has
  * the prefix stripped so it can be passed directly to evaluate/execute.
@@ -17,12 +33,6 @@ export function useMergedLocals(): readonly [
   const scope = useContext(LocalsContext);
 
   return useMemo(() => {
-    const locals: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(scope.values)) {
-      if (key.startsWith('@')) {
-        locals[key.slice(1)] = val;
-      }
-    }
-    return [variables, temporary, locals] as const;
+    return [variables, temporary, stripLocalsPrefix(scope.values)] as const;
   }, [variables, temporary, scope.values]);
 }


### PR DESCRIPTION
## Summary

- Extract `stripLocalsPrefix()` from `useMergedLocals()` as a standalone export
- Replace `useMergedLocals()` in Set, Do, Button, and MacroLink with `stripLocalsPrefix()` + `useContext(LocalsContext)`
- Mutating macros no longer subscribe to `s.variables`/`s.temporary` via Zustand, eliminating wasted re-renders

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 652 tests pass (`npx vitest run`)
- [ ] Verify merge commit preserves `release-npm` in body

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)