### PR TITLE
fix: deduplicate collectText() in Do.tsx

### DIFF
--- a/src/components/macros/Do.tsx
+++ b/src/components/macros/Do.tsx
@@ -4,16 +4,10 @@ import { LocalsUpdateContext } from '../../markup/render';
 import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
+import { collectText } from '../../utils/extract-text';
 
 interface DoProps {
   children: ASTNode[];
-}
-
-/**
- * Concatenate text children into a single JS string for execution.
- */
-function collectText(nodes: ASTNode[]): string {
-  return nodes.map((n) => (n.type === 'text' ? n.value : '')).join('');
 }
 
 export function Do({ children }: DoProps) {


### PR DESCRIPTION
## Summary
- Remove duplicate `collectText()` function from `Do.tsx` and import the shared version from `src/utils/extract-text.ts`
- No behavioral change — the implementations were identical

Closes #23

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 656 tests pass

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)