### PR TITLE
feat: eliminate @ prefix stripping round-trip in locals

### DIFF
--- a/src/components/macros/Button.tsx
+++ b/src/components/macros/Button.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'preact/hooks';
 import { renderInlineNodes, LocalsUpdateContext } from '../../markup/render';
 import { collectText } from '../../utils/extract-text';
 import { useAction } from '../../hooks/use-action';
-import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { useInterpolate } from '../../hooks/use-interpolate';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
@@ -23,7 +22,7 @@ export function Button({ rawArgs, children, className, id }: ButtonProps) {
 
   const handleClick = () => {
     try {
-      executeMutation(rawArgs, stripLocalsPrefix(getValues()), update);
+      executeMutation(rawArgs, getValues(), update);
     } catch (err) {
       console.error(
         `spindle: Error in {button ${rawArgs}}${currentSourceLocation()}:`,

--- a/src/components/macros/Do.tsx
+++ b/src/components/macros/Do.tsx
@@ -1,7 +1,6 @@
 import { useLayoutEffect, useContext } from 'preact/hooks';
 import type { ASTNode } from '../../markup/ast';
 import { LocalsUpdateContext } from '../../markup/render';
-import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
 import { collectText } from '../../utils/extract-text';
@@ -16,7 +15,7 @@ export function Do({ children }: DoProps) {
 
   useLayoutEffect(() => {
     try {
-      executeMutation(code, stripLocalsPrefix(getValues()), update);
+      executeMutation(code, getValues(), update);
     } catch (err) {
       console.error(`spindle: Error in {do}${currentSourceLocation()}:`, err);
     }

--- a/src/components/macros/For.tsx
+++ b/src/components/macros/For.tsx
@@ -52,7 +52,11 @@ function parseForArgs(rawArgs: string): {
     );
   }
 
-  return { itemVar, indexVar, listExpr };
+  return {
+    itemVar: itemVar.slice(1),
+    indexVar: indexVar ? indexVar.slice(1) : null,
+    listExpr,
+  };
 }
 
 function ForIteration({

--- a/src/components/macros/MacroLink.tsx
+++ b/src/components/macros/MacroLink.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'preact/hooks';
 import { useStoryStore } from '../../store';
 import type { ASTNode } from '../../markup/ast';
 import { LocalsUpdateContext } from '../../markup/render';
-import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { useInterpolate } from '../../hooks/use-interpolate';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
@@ -85,7 +84,7 @@ export function MacroLink({
 
   const handleClick = (e: Event) => {
     e.preventDefault();
-    executeChildren(children, stripLocalsPrefix(getValues()), update);
+    executeChildren(children, getValues(), update);
     if (passage) {
       useStoryStore.getState().navigate(passage);
     }
@@ -98,7 +97,7 @@ export function MacroLink({
     label: display,
     target: passage ?? undefined,
     perform: () => {
-      executeChildren(children, stripLocalsPrefix(getValues()), update);
+      executeChildren(children, getValues(), update);
       if (passage) {
         useStoryStore.getState().navigate(passage);
       }

--- a/src/components/macros/Set.tsx
+++ b/src/components/macros/Set.tsx
@@ -1,6 +1,5 @@
 import { useRef, useContext } from 'preact/hooks';
 import { LocalsUpdateContext } from '../../markup/render';
-import { stripLocalsPrefix } from '../../hooks/use-merged-locals';
 import { executeMutation } from '../../execute-mutation';
 import { currentSourceLocation } from '../../utils/source-location';
 
@@ -16,7 +15,7 @@ export function Set({ rawArgs }: SetProps) {
     ran.current = true;
 
     try {
-      executeMutation(rawArgs, stripLocalsPrefix(getValues()), update);
+      executeMutation(rawArgs, getValues(), update);
     } catch (err) {
       console.error(
         `spindle: Error in {set ${rawArgs}}${currentSourceLocation()}:`,

--- a/src/components/macros/VarDisplay.tsx
+++ b/src/components/macros/VarDisplay.tsx
@@ -27,8 +27,7 @@ export function VarDisplay({ name, scope, className, id }: VarDisplayProps) {
 
   let value: unknown;
   if (scope === 'local') {
-    const key = `@${root}`;
-    value = key in localsValues ? localsValues[key] : undefined;
+    value = root in localsValues ? localsValues[root] : undefined;
   } else {
     value = storeValue;
   }

--- a/src/components/macros/WidgetInvocation.tsx
+++ b/src/components/macros/WidgetInvocation.tsx
@@ -128,7 +128,7 @@ export function WidgetInvocation({
         value = undefined;
       }
     }
-    ownKeys[param] = value;
+    ownKeys[param.startsWith('@') ? param.slice(1) : param] = value;
   }
 
   return (

--- a/src/execute-mutation.ts
+++ b/src/execute-mutation.ts
@@ -26,7 +26,7 @@ export function executeMutation(
   }
   for (const key of Object.keys(localsClone)) {
     if (localsClone[key] !== mergedLocals[key]) {
-      scopeUpdate(`@${key}`, localsClone[key]);
+      scopeUpdate(key, localsClone[key]);
     }
   }
 }

--- a/src/hooks/use-merged-locals.ts
+++ b/src/hooks/use-merged-locals.ts
@@ -3,25 +3,8 @@ import { useStoryStore } from '../store';
 import { LocalsValuesContext } from '../markup/render';
 
 /**
- * Strip `@` prefix from locals scope values so they can be passed
- * directly to evaluate/execute.
- */
-export function stripLocalsPrefix(
-  values: Record<string, unknown>,
-): Record<string, unknown> {
-  const locals: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(values)) {
-    if (key.startsWith('@')) {
-      locals[key.slice(1)] = val;
-    }
-  }
-  return locals;
-}
-
-/**
- * Return store variables, temporary, and @-prefixed locals from context.
- * Locals use `@` prefix keys internally; the returned locals dict has
- * the prefix stripped so it can be passed directly to evaluate/execute.
+ * Return store variables, temporary, and locals from context.
+ * All three dicts use unprefixed keys suitable for evaluate/execute.
  */
 export function useMergedLocals(): readonly [
   Record<string, unknown>,
@@ -33,6 +16,6 @@ export function useMergedLocals(): readonly [
   const localsValues = useContext(LocalsValuesContext);
 
   return useMemo(() => {
-    return [variables, temporary, stripLocalsPrefix(localsValues)] as const;
+    return [variables, temporary, localsValues] as const;
   }, [variables, temporary, localsValues]);
 }


### PR DESCRIPTION
## Summary

- Store locals without the `@` prefix internally, removing the strip-on-read / add-on-write round-trip
- Remove `stripLocalsPrefix()` function and all callsites
- Simplify `useMergedLocals()`, `executeMutation()`, and mutating macro components

Closes #24

release-npm

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 656 unit/integration tests pass
- [x] All 177 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)