### PR TITLE
fix: timed macro CSS class/id applies per-section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow array method/property access (e.g. `$inventory.push`, `$journal.find`) in story variable validation
-- `{timed}` macro now inherits CSS class/id from its first branch when not set on the outer tag
+- `{timed}` macro CSS class/id applies per-section: each `{next}` branch's selectors only affect that branch, not the outer wrapper
 - Synchronous macro execution during render (Set, Unset, Computed update immediately rather than deferring)
 - Variables embedded in markdown code spans (backticks) are now passed through as text rather than rendered as reactive variable displays
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -370,6 +370,16 @@ Show content after a delay. Chain sections with `{next}`.
 
 Delay formats: `2s` (seconds), `500ms` (milliseconds), or `500` (bare number = milliseconds).
 
+CSS selectors apply per-section — each section's `.class#id` only affects that section:
+
+```
+{.fade-in timed 2s}
+  The door creaks open...
+  {.dramatic next 1s}
+    A figure steps out.
+{/timed}
+```
+
 ### `{repeat}`
 
 Repeat content at an interval.

--- a/src/components/macros/Timed.tsx
+++ b/src/components/macros/Timed.tsx
@@ -4,30 +4,19 @@ import { parseDelay } from '../../utils/parse-delay';
 import { useInterpolate } from '../../hooks/use-interpolate';
 import { registerMacro, registerSubMacro } from '../../registry';
 import type { MacroProps } from '../../registry';
-import type { ASTNode } from '../../markup/ast';
 
-export function Timed({
-  rawArgs,
-  children = [],
-  branches = [],
-  className,
-  id,
-}: MacroProps) {
+export function Timed({ branches = [] }: MacroProps) {
   const resolve = useInterpolate();
-  const firstBranch = branches[0];
-  className = resolve(className ?? firstBranch?.className);
-  id = resolve(id ?? firstBranch?.id);
-  // Section 0 = initial children, sections 1..N = {next} branches
-  // Each section has its own delay
+  // For branching blocks, className/id from the opening tag goes on branches[0],
+  // so the component-level className/id is unused. Each branch carries its own.
   const sections = useMemo(() => {
-    const result: { delay: number; nodes: ASTNode[] }[] = [];
-    result.push({ delay: parseDelay(rawArgs), nodes: children });
-    for (const branch of branches) {
-      const delay = branch.rawArgs ? parseDelay(branch.rawArgs) : 0;
-      result.push({ delay, nodes: branch.children });
-    }
-    return result;
-  }, [rawArgs, children, branches]);
+    return branches.map((branch) => ({
+      delay: branch.rawArgs ? parseDelay(branch.rawArgs) : 0,
+      nodes: branch.children,
+      className: branch.className,
+      id: branch.id,
+    }));
+  }, [branches]);
 
   const [visibleIndex, setVisibleIndex] = useState(-1);
 
@@ -46,13 +35,16 @@ export function Timed({
 
   if (visibleIndex < 0) return null;
 
-  const content = renderNodes(sections[visibleIndex]!.nodes);
+  const section = sections[visibleIndex]!;
+  const content = renderNodes(section.nodes);
+  const sectionClass = resolve(section.className);
+  const sectionId = resolve(section.id);
 
-  if (className || id)
+  if (sectionClass || sectionId)
     return (
       <span
-        id={id}
-        class={className}
+        id={sectionId}
+        class={sectionClass}
       >
         {content}
       </span>

--- a/test/dom/timed.test.tsx
+++ b/test/dom/timed.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { Passage } from '../../src/components/Passage';
+import { useStoryStore } from '../../src/store';
+import type { StoryData, Passage as PassageData } from '../../src/parser';
+
+function makePassage(pid: number, name: string, content: string): PassageData {
+  return { pid, name, tags: [], metadata: {}, content };
+}
+
+function makeStoryData(passages: PassageData[], startNode = 1): StoryData {
+  const byName = new Map(passages.map((p) => [p.name, p]));
+  const byId = new Map(passages.map((p) => [p.pid, p]));
+  return {
+    name: 'Test',
+    startNode,
+    ifid: 'test',
+    format: 'spindle',
+    formatVersion: '0.1.0',
+    passages: byName,
+    passagesById: byId,
+    userCSS: '',
+    userScript: '',
+  };
+}
+
+function renderPassage(content: string): HTMLElement {
+  const passage = makePassage(1, 'Test', content);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    render(<Passage passage={passage} />, container);
+  });
+  return container;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForText(
+  el: HTMLElement,
+  text: string,
+  timeout = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (el.textContent?.includes(text)) return;
+    await wait(10);
+  }
+  throw new Error(`Timed out waiting for "${text}" in: ${el.textContent}`);
+}
+
+describe('{timed} className and id', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const store = useStoryStore.getState();
+    store.init(makeStoryData([makePassage(1, 'Start', 'Start')]));
+  });
+
+  it('renders nothing before the delay', () => {
+    const el = renderPassage('{timed 100ms}Hello{/timed}');
+    expect(el.textContent).not.toContain('Hello');
+  });
+
+  it('renders initial content after the delay', async () => {
+    const el = renderPassage('{timed 50ms}Hello{/timed}');
+    await waitForText(el, 'Hello');
+  });
+
+  it('applies className and id from the opening tag section', async () => {
+    const el = renderPassage('{.fade#intro timed 50ms}Hello{/timed}');
+    await waitForText(el, 'Hello');
+    const span = el.querySelector('span.fade#intro');
+    expect(span).not.toBeNull();
+    expect(span!.textContent).toBe('Hello');
+  });
+
+  it('applies className/id only to the section that declares them', async () => {
+    const el = renderPassage(
+      '{timed 50ms}Initial{.highlight#second next 50ms}Second{/timed}',
+    );
+    // First section has no className/id
+    await waitForText(el, 'Initial');
+    expect(el.querySelector('.highlight')).toBeNull();
+    expect(el.querySelector('#second')).toBeNull();
+
+    // Second section gets its own className/id
+    await waitForText(el, 'Second');
+    const span = el.querySelector('span.highlight#second');
+    expect(span).not.toBeNull();
+    expect(span!.textContent).toBe('Second');
+  });
+
+  it('className from opening tag does not leak to {next} branches', async () => {
+    const el = renderPassage('{.first timed 50ms}One{next 50ms}Two{/timed}');
+    await waitForText(el, 'One');
+    expect(el.querySelector('span.first')).not.toBeNull();
+
+    // Second section has no className — no wrapping span
+    await waitForText(el, 'Two');
+    expect(el.querySelector('.first')).toBeNull();
+  });
+
+  it('each branch id is independent', async () => {
+    const el = renderPassage(
+      '{#first timed 50ms}One{#second next 50ms}Two{/timed}',
+    );
+    await waitForText(el, 'One');
+    expect(el.querySelector('#first')).not.toBeNull();
+    expect(el.querySelector('#second')).toBeNull();
+
+    await waitForText(el, 'Two');
+    expect(el.querySelector('#second')).not.toBeNull();
+    expect(el.querySelector('#first')).toBeNull();
+  });
+
+  it('renders without wrapper when no className or id', async () => {
+    const el = renderPassage('{timed 50ms}Plain{next 50ms}Also plain{/timed}');
+    await waitForText(el, 'Plain');
+    // No wrapping span inside the passage div
+    const passageDiv = el.querySelector('.passage')!;
+    expect(passageDiv.querySelector('span')).toBeNull();
+
+    await waitForText(el, 'Also plain');
+    expect(passageDiv.querySelector('span')).toBeNull();
+  });
+
+  it('cycles through multiple branches with independent styles', async () => {
+    const el = renderPassage(
+      '{.a timed 50ms}One{.b next 50ms}Two{.c#end next 50ms}Three{/timed}',
+    );
+    // Section 0: class "a" only
+    await waitForText(el, 'One');
+    expect(el.querySelector('span.a')).not.toBeNull();
+    expect(el.querySelector('.b')).toBeNull();
+    expect(el.querySelector('.c')).toBeNull();
+
+    // Section 1: class "b" only
+    await waitForText(el, 'Two');
+    expect(el.querySelector('span.b')).not.toBeNull();
+    expect(el.querySelector('.a')).toBeNull();
+
+    // Section 2: class "c", id "end"
+    await waitForText(el, 'Three');
+    const span = el.querySelector('span.c#end');
+    expect(span).not.toBeNull();
+    expect(span!.textContent).toBe('Three');
+    expect(el.querySelector('.b')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Each `{next}` branch's `.class#id` now only affects that branch's content, not the outer wrapper
- Simplified `Timed` component to map directly over branches (the AST puts all content there for branching block macros)
- Added 8 tests covering per-section className/id behavior
- Updated docs and changelog

## Test plan

- [x] All 664 unit/dom tests pass
- [x] All 177 e2e tests pass (including timed content tests)
- [x] TypeScript compiles clean

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)