### PR TITLE
fix: build before test in prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "prepublishOnly": "bun run test && bun run build",
+    "prepublishOnly": "bun run build && bun run test",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Swaps `prepublishOnly` script order from `test && build` to `build && test`
- Fixes npm release failure where semantic-release bumps `package.json` version but `dist/format.js` still has the old version when tests run

## Context
Failed run: https://github.com/rohal12/spindle/actions/runs/22821801248

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)