### PR TITLE
feat: watch/unwatch triggers, button convention flip, macro-agnostic StoryInit

### DIFF
--- a/dev/story.twee
+++ b/dev/story.twee
@@ -45,6 +45,8 @@ $forBtnPick = 0
 $ready_count = 0
 $done_count = 0
 $ready_conditional = false
+$watchTest = 0
+$watchGold = 0
 
 
 :: StoryInit
@@ -99,7 +101,7 @@ A wooden door stands to the north. Through a crack beneath it, you see flickerin
 
 [[Computed vars->Computed Var Tests]] | [[Unset tests->Unset Tests]] | [[Link syntax->Link Syntax Edge Cases]]
 
-[[Code passages->Code Passages Test]]
+[[Code passages->Code Passages Test]] | [[Watch triggers->Watch Tests]]
 
 :: Hallway
 {set $visited_rooms = $visited_rooms + 1}
@@ -252,7 +254,7 @@ This passage demonstrates all macros.
 
 Reactivity — press the button to increment the counter:
 
-Count: {$count} {if $count < 10}{button $count = $count + 1}+1{/button}{else}[[You reached 10! Continue->Start]]{/if}
+Count: {$count} {if $count < 10}{button "+1"}{set $count = $count + 1}{/button}{else}[[You reached 10! Continue->Start]]{/if}
 
 Unlike traditional Twine formats that re-render the entire passage, only the count and the button area above re-render. Everything else on the page stays untouched.
 
@@ -279,10 +281,10 @@ Health: {$player.hp}/{$player.maxHp} —
 
 
 {if $player.hp > 0}
-  {.red button $player.damage(10)}Drink Poison{/button}
+  {.red button "Drink Poison"}{do}$player.damage(10){/do}{/button}
 {/if}
 {if $player.hp < $player.maxHp}
-  {.green button $player.heal(10)}Drink Health potion{/button}
+  {.green button "Drink Health potion"}{do}$player.heal(10){/do}{/button}
 {/if}
 
 
@@ -305,11 +307,11 @@ CSS class syntax:
 
 {.highlight if $player.hp < 50}You're hurt!{/if} — if with class
 
-{.danger button $player.damage(10)}Take 10 (styled){/button} — button with class
+{.danger button "Take 10 (styled)"}{do}$player.damage(10){/do}{/button} — button with class
 
 [[.fancy Back to start|Start]] — link with class
 
-{.danger.large button $player.damage(5)}Multi-class button{/button} — multiple classes
+{.danger.large button "Multi-class button"}{do}$player.damage(5){/do}{/button} — multiple classes
 
 
 All link syntaxes:
@@ -391,21 +393,21 @@ Authors can target it with CSS using [data-tags~="special"].
 ### Debug
 Current level: {$player.level}
 
-{button $player.level++}Level Up!{/button}
+{button "Level Up!"}{do}$player.level++{/do}{/button}
 
 ### Character Generation
 
 | Stat | Base | | New | |
 | --- | --- | --- | --- | --- |
-| Strength | {$player.strength} | → | {_temp.strength} | {if _temp.strength > $player.strength}{button _temp.strength--}-{/button}{/if} {if _points > 0}{button _temp.strength++}+{/button}{/if} |
-| Dexterity | {$player.dexterity} | → | {_temp.dexterity} | {if _temp.dexterity > $player.dexterity}{button _temp.dexterity--}-{/button}{/if} {if _points > 0}{button _temp.dexterity++}+{/button}{/if} |
-| Intelligence | {$player.intelligence} | → | {_temp.intelligence} | {if _temp.intelligence > $player.intelligence}{button _temp.intelligence--}-{/button}{/if} {if _points > 0}{button _temp.intelligence++}+{/button}{/if} |
+| Strength | {$player.strength} | → | {_temp.strength} | {if _temp.strength > $player.strength}{button "-"}{do}_temp.strength--{/do}{/button}{/if} {if _points > 0}{button "+"}{do}_temp.strength++{/do}{/button}{/if} |
+| Dexterity | {$player.dexterity} | → | {_temp.dexterity} | {if _temp.dexterity > $player.dexterity}{button "-"}{do}_temp.dexterity--{/do}{/button}{/if} {if _points > 0}{button "+"}{do}_temp.dexterity++{/do}{/button}{/if} |
+| Intelligence | {$player.intelligence} | → | {_temp.intelligence} | {if _temp.intelligence > $player.intelligence}{button "-"}{do}_temp.intelligence--{/do}{/button}{/if} {if _points > 0}{button "+"}{do}_temp.intelligence++{/do}{/button}{/if} |
 
 {if _points > 0}**Points remaining:** {_points}{/if}
 {if _points == 0}**All points allocated**{/if}
 
 {if _points == 0}
-{button $player = _temp}Confirm{/button} [[Go Back -> Start]]
+{button "Confirm"}{set $player = _temp}{/button} [[Go Back -> Start]]
 {/if}
 
 :: Widgets [widget]
@@ -810,10 +812,10 @@ The story variable should persist: {$storyVar}
 **Button that sets temp var:**
 {set _btnResult = "before"}
 Result: {_btnResult}
-{#set-temp-btn button _btnResult = "after"}Change Temp{/button}
+{#set-temp-btn button "Change Temp"}{set _btnResult = "after"}{/button}
 
 **Button with expression:**
-{#expr-btn button $count = $count + 5}Add 5{/button}
+{#expr-btn button "Add 5"}{set $count = $count + 5}{/button}
 Count after: {$count}
 
 **Link macro without passage (action only):**
@@ -919,7 +921,7 @@ Key state: {$has_key}
 **For loop with button inside:**
 {set $forBtnCount = 0}
 {for @label of ["X", "Y"]}
-  {button $forBtnCount = $forBtnCount + 1}{@label}{/button}
+  {button "{@label}"}{set $forBtnCount = $forBtnCount + 1}{/button}
 {/for}
 For-btn count: {$forBtnCount}
 
@@ -959,7 +961,7 @@ For-btn count: {$forBtnCount}
 **Button inside for-loop picks correct @local:**
 {set $forBtnPick = 0}
 {for @val of [10, 20, 30]}
-  {button $forBtnPick = @val}<span class="for-pick-btn">Pick {@val}</span>{/button}
+  {.for-pick-btn button "Pick {@val}"}{set $forBtnPick = @val}{/button}
 {/for}
 <span id="for-btn-pick">Picked: {$forBtnPick}</span>
 
@@ -1134,3 +1136,27 @@ Ready conditional: {.ready-cond span}{$ready_conditional}{/span}
 
 :: Code Passages Return
 Intermediate passage. [[Return->Code Passages Test]]
+
+:: Watch Tests
+{watch '$watchTest >= 3' dialog "Watch Dialog Result" once}
+{watch '$watchGold >= 100' goto "Watch Goto Result" once name "gold-watch"}
+
+Current watchTest: {$watchTest}
+Current watchGold: {$watchGold}
+
+{button "Increment watchTest"}{set $watchTest = $watchTest + 1}{/button}
+
+{button "Set watchTest to 5"}{set $watchTest = 5}{/button}
+
+{button "Set gold to 100"}{set $watchGold = 100}{/button}
+
+{button "Unwatch gold"}{unwatch "gold-watch"}{/button}
+
+[[Start]]
+
+:: Watch Dialog Result
+The watchTest variable reached 3 or more! This dialog was triggered by a watch.
+
+:: Watch Goto Result
+You reached 100 gold! This passage was reached via a watch goto.
+[[Watch Tests]]

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -190,27 +190,26 @@ The primary way to navigate. See [Markup](markup.md#links).
 
 ### `{link}`
 
-A link macro that can execute code when clicked.
+A link that navigates to a passage. The display text and target passage go in the opening tag as quoted strings. An optional body can contain macros that execute on click before navigation.
 
 ```
-{link "Go north" "North Room"}Click to go north{/link}
+{link "Go north" "North Room"}{/link}
 ```
 
-With variable changes embedded in the body:
+With macros in the body:
 
 ```
 {link "Take key" "Next Room"}
   {set $has_key = true}
-  Pick up the key
 {/link}
 ```
 
-Any `{set}` or `{do}` macros inside the link body execute when clicked, before navigation.
+Body macros execute when clicked, before navigation.
 
 If only one quoted string is given, it's used as both display and passage:
 
 ```
-{link "North Room"}Go north{/link}
+{link "North Room"}{/link}
 ```
 
 ### `{goto}`
@@ -226,14 +225,25 @@ Runs during rendering, so the passage changes instantly.
 
 ### `{button}`
 
-A clickable button that executes code.
+A clickable button that runs its body macros on click. The label goes in the opening tag (supports interpolation), the body contains macros like `{set}` or `{do}`.
 
 ```
-{button $health -= 10}Take damage{/button}
-{button $count = $count + 1}+1{/button}
+{button "Take damage"}{do}$health -= 10{/do}{/button}
+{button "Count: {$count}"}{set $count = $count + 1}{/button}
 ```
 
-Unlike `{link}`, a button does not navigate to another passage — it only runs the code in `rawArgs` when clicked.
+Unlike `{link}`, a button does not navigate to another passage — it only runs the body macros when clicked.
+
+### `{dialog}`
+
+A button that opens a modal dialog showing another passage. The label goes in the opening tag, the passage name goes in the body.
+
+```
+{dialog "Open Map"}Map{/dialog}
+{dialog "View Inventory"}Inventory Screen{/dialog}
+```
+
+The dialog closes when the player clicks outside it or presses Escape.
 
 ### `{back}`
 
@@ -446,6 +456,38 @@ Define a reusable content block. Optionally declare parameters after the name.
 ```
 
 Invoke with arguments: `{StatLine "Health", $health, 100}`. See [Widgets](widgets.md).
+
+## Watchers
+
+### `{watch}`
+
+An edge-triggered watcher that monitors a condition and fires an action when it becomes true. The condition is a quoted expression string, followed by keyword options.
+
+```
+{watch '$health <= 0' dialog "Game Over" once}
+{watch '$gold >= 100' goto "Victory" once name "gold-watch"}
+```
+
+| Option     | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `dialog`   | Show a passage as a modal dialog                   |
+| `goto`     | Navigate to a passage                              |
+| `run`      | Execute a code string (e.g. `run "$health -= 1"`)  |
+| `once`     | Remove the watcher after it fires once             |
+| `name`     | Name the watcher for later removal via `{unwatch}` |
+| `priority` | Numeric priority (higher fires first)              |
+
+Watchers are **edge-triggered** — they fire only on a `false → true` transition of the condition. A condition that is already true when the watcher is registered will not fire until it becomes false and then true again.
+
+Watchers survive passage navigation but are cleared on restart. Place them in `StoryInit` to register them on every playthrough.
+
+### `{unwatch}`
+
+Remove a named watcher.
+
+```
+{unwatch "gold-watch"}
+```
 
 ## Saves and UI
 

--- a/docs/markup.md
+++ b/docs/markup.md
@@ -70,7 +70,7 @@ Prefix `.class` or `#id` selectors inside the opening brace:
 
 {.large#title print $name}
 
-{.danger button $health = 0}Die{/button}
+{.danger button "Die"}{set $health = 0}{/button}
 ```
 
 Multiple classes are space-joined: `{.red.bold print $x}` produces `class="red bold"`.

--- a/docs/special-passages.md
+++ b/docs/special-passages.md
@@ -18,7 +18,7 @@ Runs once when the story first loads and again on every restart. Use it to set u
 {/do}
 ```
 
-Only `{set}` and `{do}` macros are executed in `StoryInit` — other content is ignored. This passage is never displayed to the player.
+Any macro works in `StoryInit` — all macros execute through the normal rendering pipeline, but the passage content is never displayed to the player.
 
 If a `StoryVariables` passage exists, its defaults are applied _before_ `StoryInit` runs, so `StoryInit` can override or build on those defaults.
 

--- a/docs/story-api.md
+++ b/docs/story-api.md
@@ -47,6 +47,33 @@ Go to the next passage in history (after going back).
 
 Restart the story. Restores variable defaults and re-runs `StoryInit`.
 
+### `Story.watch(condition, callbackOrOptions)`
+
+Register an edge-triggered watcher. Fires the callback or action when the condition transitions from false to true. Returns an unsubscribe function.
+
+```
+{do}
+  // Callback style
+  Story.watch('$health <= 0', function() { Story.goto('Game Over'); });
+
+  // Options style
+  Story.watch('$health <= 0', { dialog: 'Game Over', once: true });
+  Story.watch('$gold >= 100', { goto: 'Victory', once: true, name: 'gold-watch' });
+{/do}
+```
+
+Options: `goto`, `dialog`, `run`, `once`, `name`, `priority`. See [`{watch}` macro](macros.md#watch) for details.
+
+### `Story.unwatch(name)`
+
+Remove a named watcher.
+
+```
+{do}
+  Story.unwatch('gold-watch');
+{/do}
+```
+
 ### `Story.save()`
 
 Perform a quick save.
@@ -244,7 +271,7 @@ Action types: `link`, `button`, `cycle`, `textbox`, `numberbox`, `textarea`, `ch
 IDs are generated automatically from the action type and a content-based key:
 
 - Links: `link:PassageName`
-- Buttons: `button:$count = $count + 1`
+- Buttons: `button:"Take damage"`
 - Inputs: `textbox:$name`, `cycle:$weapon`
 - Menubar: `back:back`, `forward:forward`, `restart:restart`, `save:quicksave`, `load:quickload`
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { useStoryStore } from '../store';
 import { StoryInterface } from './StoryInterface';
+import { TriggerDialogHost } from './TriggerDialogHost';
 
 export function App() {
   const storyData = useStoryStore((s) => s.storyData);
@@ -24,5 +25,10 @@ export function App() {
     return <div class="loading">Loading...</div>;
   }
 
-  return <StoryInterface />;
+  return (
+    <>
+      <StoryInterface />
+      <TriggerDialogHost />
+    </>
+  );
 }

--- a/src/components/TriggerDialogHost.tsx
+++ b/src/components/TriggerDialogHost.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'preact/hooks';
+import { PassageDialog } from './PassageDialog';
+import {
+  subscribeTriggerDialogs,
+  shiftDialogQueue,
+  dialogQueueLength,
+} from '../triggers';
+
+export function TriggerDialogHost() {
+  const [current, setCurrent] = useState<string | null>(null);
+
+  const advance = useCallback(() => {
+    const next = shiftDialogQueue();
+    setCurrent(next ?? null);
+  }, []);
+
+  useEffect(() => {
+    return subscribeTriggerDialogs(() => {
+      setCurrent((prev) => {
+        if (prev !== null) return prev; // already showing one
+        return shiftDialogQueue() ?? null;
+      });
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setCurrent(null);
+    // Show next queued dialog after a tick
+    if (dialogQueueLength() > 0) {
+      requestAnimationFrame(advance);
+    }
+  }, [advance]);
+
+  if (!current) return null;
+
+  return (
+    <PassageDialog
+      passageName={current}
+      onClose={handleClose}
+    />
+  );
+}

--- a/src/components/macros/Button.tsx
+++ b/src/components/macros/Button.tsx
@@ -1,25 +1,40 @@
+import { h, render } from 'preact';
 import { defineMacro } from '../../define-macro';
+import {
+  renderNodes,
+  LocalsUpdateContext,
+  LocalsValuesContext,
+} from '../../markup/render';
 
 defineMacro({
   name: 'button',
   interpolate: true,
   render({ rawArgs, children = [] }, ctx) {
+    const label = ctx.resolve?.(rawArgs.replace(/^["']|["']$/g, '')) ?? rawArgs;
+
     const handleClick = () => {
-      try {
-        ctx.mutate(rawArgs);
-      } catch (err) {
-        console.error(
-          `spindle: Error in {button ${rawArgs}}${ctx.sourceLocation()}:`,
-          err,
-        );
-      }
+      // Render children into a detached DOM node — all macro side effects
+      // ({set}, {if}, {unwatch}, etc.) fire through the normal Preact pipeline.
+      // Wrap with locals context so @local variables from for-loops are available.
+      const container = document.createElement('div');
+      const vnode = h(
+        LocalsUpdateContext.Provider,
+        { value: { update: ctx.update, getValues: ctx.getValues } },
+        h(
+          LocalsValuesContext.Provider,
+          { value: ctx.getValues() },
+          renderNodes(children),
+        ),
+      );
+      render(vnode, container);
+      render(null, container);
     };
 
     ctx.useAction({
       type: 'button',
       key: rawArgs,
       authorId: ctx.id,
-      label: ctx.collectText(children) || rawArgs,
+      label,
       perform: handleClick,
     });
 
@@ -29,7 +44,7 @@ defineMacro({
         class={ctx.cls}
         onClick={handleClick}
       >
-        {ctx.renderInlineNodes(children)}
+        {label}
       </button>
     );
   },

--- a/src/components/macros/Dialog.tsx
+++ b/src/components/macros/Dialog.tsx
@@ -3,21 +3,15 @@ import { PassageDialog } from '../PassageDialog';
 
 defineMacro({
   name: 'dialog',
-  merged: true,
+  interpolate: true,
   render({ rawArgs, children = [] }, ctx) {
     const [open, setOpen] = ctx.hooks.useState(false);
 
-    let passageName: string;
-    try {
-      const result = ctx.evaluate!(rawArgs);
-      passageName = String(result);
-    } catch {
-      passageName = rawArgs.replace(/^["']|["']$/g, '').trim();
-    }
-
-    const label = children.length
-      ? ctx.renderInlineNodes(children)
-      : passageName;
+    const label = ctx.resolve?.(rawArgs.replace(/^["']|["']$/g, '')) ?? rawArgs;
+    const passageName = ctx
+      .collectText(children)
+      .trim()
+      .replace(/^["']|["']$/g, '');
 
     return (
       <>

--- a/src/components/macros/MacroLink.tsx
+++ b/src/components/macros/MacroLink.tsx
@@ -1,8 +1,10 @@
+import { h, render } from 'preact';
 import { useStoryStore } from '../../store';
-import type { ASTNode } from '../../markup/ast';
-import { executeMutation } from '../../execute-mutation';
-import { collectText } from '../../utils/extract-text';
-import { currentSourceLocation } from '../../utils/source-location';
+import {
+  renderNodes,
+  LocalsUpdateContext,
+  LocalsValuesContext,
+} from '../../markup/render';
 import { defineMacro } from '../../define-macro';
 
 function parseArgs(rawArgs: string): {
@@ -26,37 +28,23 @@ function parseArgs(rawArgs: string): {
   return { display: rawArgs.trim(), passage: null };
 }
 
-/**
- * Execute the children imperatively: walk AST for {set} and {do} macros.
- */
-function executeChildren(
-  children: ASTNode[],
-  mergedLocals: Record<string, unknown>,
-  scopeUpdate: (key: string, value: unknown) => void,
+function renderChildrenDetached(
+  children: import('../../markup/ast').ASTNode[],
+  getValues: () => Record<string, unknown>,
+  update: (key: string, value: unknown) => void,
 ) {
-  for (const node of children) {
-    if (node.type !== 'macro') continue;
-    if (node.name === 'set') {
-      try {
-        executeMutation(node.rawArgs, mergedLocals, scopeUpdate);
-      } catch (err) {
-        console.error(
-          `spindle: Error in {link} child {set}${currentSourceLocation()}:`,
-          err,
-        );
-      }
-    } else if (node.name === 'do') {
-      const code = collectText(node.children);
-      try {
-        executeMutation(code, mergedLocals, scopeUpdate);
-      } catch (err) {
-        console.error(
-          `spindle: Error in {link} child {do}${currentSourceLocation()}:`,
-          err,
-        );
-      }
-    }
-  }
+  const container = document.createElement('div');
+  const vnode = h(
+    LocalsUpdateContext.Provider,
+    { value: { update, getValues } },
+    h(
+      LocalsValuesContext.Provider,
+      { value: getValues() },
+      renderNodes(children),
+    ),
+  );
+  render(vnode, container);
+  render(null, container);
 }
 
 defineMacro({
@@ -67,7 +55,7 @@ defineMacro({
 
     const handleClick = (e: Event) => {
       e.preventDefault();
-      executeChildren(children, ctx.getValues(), ctx.update);
+      renderChildrenDetached(children, ctx.getValues, ctx.update);
       if (passage) {
         useStoryStore.getState().navigate(passage);
       }
@@ -80,7 +68,7 @@ defineMacro({
       label: display,
       target: passage ?? undefined,
       perform: () => {
-        executeChildren(children, ctx.getValues(), ctx.update);
+        renderChildrenDetached(children, ctx.getValues, ctx.update);
         if (passage) {
           useStoryStore.getState().navigate(passage);
         }

--- a/src/components/macros/Watch.tsx
+++ b/src/components/macros/Watch.tsx
@@ -1,0 +1,75 @@
+import { defineMacro } from '../../define-macro';
+import { addTrigger, removeTrigger } from '../../triggers';
+import type { WatchOptions } from '../../triggers';
+
+defineMacro({
+  name: 'watch',
+  render(props, ctx) {
+    const { hooks } = ctx;
+
+    // Parse: condition string + keyword options
+    const raw = props.rawArgs.trim();
+    // First quoted string is the condition
+    const condMatch = raw.match(/^(['"])(.*?)\1\s*/);
+    if (!condMatch) return null;
+
+    const condition = condMatch[2]!;
+    const rest = raw.slice(condMatch[0].length);
+
+    const options: WatchOptions = {};
+    // Parse keyword args: goto "X", dialog "X", run "X", once, name "X", priority N
+    const kwRe = /(\w+)\s+(?:"([^"]*?)"|'([^']*?)'|(\d+))|(\w+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = kwRe.exec(rest)) !== null) {
+      const key = m[1] ?? m[5];
+      const val = m[2] ?? m[3] ?? m[4];
+      if (!key) continue;
+      switch (key) {
+        case 'goto':
+          options.goto = val;
+          break;
+        case 'dialog':
+          options.dialog = val;
+          break;
+        case 'run':
+          options.run = val;
+          break;
+        case 'name':
+          options.name = val;
+          break;
+        case 'priority':
+          options.priority = val ? Number(val) : 0;
+          break;
+        case 'once':
+          options.once = true;
+          break;
+      }
+    }
+
+    // Register during render (like {set}) — triggers survive navigation
+    // and are cleaned up via resetTriggers() on restart or {unwatch}.
+    const registered = hooks.useRef(false);
+    if (!registered.current) {
+      registered.current = true;
+      addTrigger(condition, options);
+    }
+
+    return null;
+  },
+});
+
+defineMacro({
+  name: 'unwatch',
+  render(props, ctx) {
+    const raw = props.rawArgs.trim();
+    const name = raw.replace(/^['"]|['"]$/g, '');
+
+    const ran = ctx.hooks.useRef(false);
+    if (!ran.current) {
+      ran.current = true;
+      removeTrigger(name);
+    }
+
+    return null;
+  },
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { useStoryStore } from './store';
 import { installStoryAPI } from './story-api';
 import { resetIdCounters } from './action-registry';
 import { executeStoryInit } from './story-init';
+import { checkTriggers, reinitTriggerState } from './triggers';
 import { loadSession } from './saves/save-manager';
 import {
   parseStoryVariables,
@@ -124,6 +125,21 @@ function boot() {
       prevPassage = state.currentPassage;
       resetIdCounters();
     }
+  });
+
+  // Wire up trigger system: check triggers on variable mutations, reinit on history nav/load
+  let prevVars = useStoryStore.getState().variables;
+  let prevHistoryIndex = useStoryStore.getState().historyIndex;
+  useStoryStore.subscribe((state) => {
+    if (state.variables !== prevVars) {
+      if (state.historyIndex === prevHistoryIndex) {
+        checkTriggers();
+      } else {
+        reinitTriggerState();
+      }
+    }
+    prevVars = state.variables;
+    prevHistoryIndex = state.historyIndex;
   });
 
   // Warn if StoryInterface passage exists but doesn't contain {passage}

--- a/src/macros/register-builtins.ts
+++ b/src/macros/register-builtins.ts
@@ -31,3 +31,4 @@ import '../components/macros/Listbox';
 import '../components/macros/Cycle';
 import '../components/macros/Span';
 import '../components/macros/PassageDisplay';
+import '../components/macros/Watch';

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import {
 import type { StoryData } from './parser';
 import type { SavePayload, SaveHistoryMoment } from './saves/types';
 import { executeStoryInit } from './story-init';
+import { resetTriggers } from './triggers';
 import {
   initSaveSystem,
   startNewPlaythrough,
@@ -441,6 +442,7 @@ export const useStoryStore = create<StoryState>()(
       if (!startPassage) return;
 
       resetPRNG();
+      resetTriggers();
       const initialVars = deepClone(variableDefaults);
       resetModuleState(deepClone(initialVars));
 

--- a/src/story-api.ts
+++ b/src/story-api.ts
@@ -21,6 +21,8 @@ import {
   randomInt,
   snapshotPRNG,
 } from './prng';
+import { addTrigger, removeTrigger } from './triggers';
+import type { WatchOptions } from './triggers';
 
 export type { StoryAction };
 
@@ -65,6 +67,11 @@ export interface StoryAPI {
   on(event: 'actionsChanged', callback: ActionsChangedCallback): () => void;
   on(event: 'variableChanged', callback: VariableChangedCallback): () => void;
   waitForActions(): Promise<StoryAction[]>;
+  watch(
+    condition: string,
+    callbackOrOptions: (() => void) | WatchOptions,
+  ): () => void;
+  unwatch(name: string): void;
   random(): number;
   randomInt(min: number, max: number): number;
   readonly config: {
@@ -261,6 +268,17 @@ function createStoryAPI(): StoryAPI {
           });
         });
       });
+    },
+
+    watch(
+      condition: string,
+      callbackOrOptions: (() => void) | WatchOptions,
+    ): () => void {
+      return addTrigger(condition, callbackOrOptions);
+    },
+
+    unwatch(name: string): void {
+      removeTrigger(name);
     },
 
     random(): number {

--- a/src/story-init.ts
+++ b/src/story-init.ts
@@ -1,63 +1,30 @@
+import { h, render } from 'preact';
 import { useStoryStore } from './store';
 import { tokenize } from './markup/tokenizer';
 import { buildAST } from './markup/ast';
-import { execute } from './expression';
-import type { ASTNode } from './markup/ast';
+import { renderNodes } from './markup/render';
 import { setSaveTitlePassage } from './saves/save-manager';
-import { deepClone } from './class-registry';
 
 /**
- * Walk AST nodes from StoryInit and execute {set} and {do} imperatively
- * (no Preact rendering needed for initialization).
- */
-function walkAndExecute(
-  nodes: ASTNode[],
-  vars: Record<string, unknown>,
-  temps: Record<string, unknown>,
-) {
-  for (const node of nodes) {
-    if (node.type !== 'macro') continue;
-
-    if (node.name === 'set') {
-      execute(node.rawArgs, vars, temps);
-    } else if (node.name === 'do') {
-      const code = node.children
-        .map((n) => (n.type === 'text' ? n.value : ''))
-        .join('');
-      execute(code, vars, temps);
-    }
-  }
-}
-
-/**
- * Execute the StoryInit passage: tokenize, parse, and run all {set}/{do} macros.
- * Called during boot and after restart() to ensure variables are initialized.
+ * Execute the StoryInit passage: tokenize, parse, and render all macros
+ * into a detached DOM node so their side effects fire through the normal
+ * Preact pipeline. This is macro-agnostic — any macro works in StoryInit.
  */
 export function executeStoryInit() {
   const state = useStoryStore.getState();
   if (!state.storyData) return;
 
   const storyInit = state.storyData.passages.get('StoryInit');
-  if (!storyInit) return;
+  if (storyInit) {
+    const tokens = tokenize(storyInit.content);
+    const ast = buildAST(tokens);
 
-  const tokens = tokenize(storyInit.content);
-  const ast = buildAST(tokens);
-
-  const vars = deepClone(state.variables);
-  const temps = deepClone(state.temporary);
-
-  walkAndExecute(ast, vars, temps);
-
-  // Apply all changes to the store
-  for (const key of Object.keys(vars)) {
-    if (vars[key] !== state.variables[key]) {
-      state.setVariable(key, vars[key]);
-    }
-  }
-  for (const key of Object.keys(temps)) {
-    if (temps[key] !== state.temporary[key]) {
-      state.setTemporary(key, temps[key]);
-    }
+    const container = document.createElement('div');
+    render(
+      h(() => renderNodes(ast) as any, null),
+      container,
+    );
+    render(null, container);
   }
 
   // Register SaveTitle passage if it exists

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -1,0 +1,161 @@
+import { evaluate, execute } from './expression';
+import { useStoryStore } from './store';
+
+export interface WatchOptions {
+  goto?: string;
+  dialog?: string;
+  run?: string;
+  once?: boolean;
+  name?: string;
+  priority?: number;
+}
+
+interface Trigger {
+  id: number;
+  name?: string;
+  condition: string;
+  callback?: () => void;
+  options?: WatchOptions;
+  lastResult: boolean;
+  priority: number;
+}
+
+let nextId = 0;
+let triggers: Trigger[] = [];
+let checking = false;
+
+type DialogCallback = () => void;
+let dialogQueue: string[] = [];
+let dialogNotify: DialogCallback | null = null;
+
+function evalCondition(condition: string): boolean {
+  const state = useStoryStore.getState();
+  try {
+    return !!evaluate(condition, state.variables, state.temporary);
+  } catch {
+    return false;
+  }
+}
+
+export function addTrigger(
+  condition: string,
+  callbackOrOptions: (() => void) | WatchOptions,
+): () => void {
+  const id = nextId++;
+  const isCallback = typeof callbackOrOptions === 'function';
+  const options = isCallback ? undefined : callbackOrOptions;
+  const callback = isCallback ? callbackOrOptions : undefined;
+
+  const trigger: Trigger = {
+    id,
+    name: options?.name,
+    condition,
+    callback,
+    options,
+    lastResult: evalCondition(condition),
+    priority: options?.priority ?? 0,
+  };
+
+  triggers.push(trigger);
+  triggers.sort((a, b) => b.priority - a.priority);
+
+  return () => {
+    triggers = triggers.filter((t) => t.id !== id);
+  };
+}
+
+export function removeTrigger(name: string): void {
+  triggers = triggers.filter((t) => t.name !== name);
+}
+
+function fireTrigger(trigger: Trigger): void {
+  const { callback, options } = trigger;
+
+  if (callback) {
+    callback();
+    return;
+  }
+
+  if (!options) return;
+
+  if (options.run) {
+    const state = useStoryStore.getState();
+    execute(options.run, state.variables, state.temporary);
+  }
+
+  if (options.dialog) {
+    dialogQueue.push(options.dialog);
+    dialogNotify?.();
+  }
+
+  if (options.goto) {
+    useStoryStore.getState().navigate(options.goto);
+  }
+}
+
+const MAX_RECHECK_DEPTH = 10;
+
+export function checkTriggers(): void {
+  if (checking) return;
+  checking = true;
+
+  try {
+    for (let depth = 0; depth < MAX_RECHECK_DEPTH; depth++) {
+      let anyFired = false;
+
+      // Snapshot triggers list — firing may remove `once` triggers
+      const current = [...triggers];
+      for (const trigger of current) {
+        // Skip if removed during this cycle
+        if (!triggers.includes(trigger)) continue;
+
+        const result = evalCondition(trigger.condition);
+        const wasFalse = !trigger.lastResult;
+        trigger.lastResult = result;
+
+        if (result && wasFalse) {
+          anyFired = true;
+
+          if (trigger.options?.once) {
+            triggers = triggers.filter((t) => t.id !== trigger.id);
+          }
+
+          fireTrigger(trigger);
+        }
+      }
+
+      if (!anyFired) break;
+    }
+  } finally {
+    checking = false;
+  }
+}
+
+export function reinitTriggerState(): void {
+  for (const trigger of triggers) {
+    trigger.lastResult = evalCondition(trigger.condition);
+  }
+}
+
+export function resetTriggers(): void {
+  triggers = [];
+  dialogQueue = [];
+  nextId = 0;
+}
+
+export function subscribeTriggerDialogs(cb: () => void): () => void {
+  dialogNotify = cb;
+  // Flush any queued dialogs
+  if (dialogQueue.length > 0) cb();
+  return () => {
+    if (dialogNotify === cb) dialogNotify = null;
+  };
+}
+
+export function shiftDialogQueue(): string | undefined {
+  return dialogQueue.shift();
+}
+
+export function dialogQueueLength(): number {
+  return dialogQueue.length;
+}

--- a/test/dom/macros.test.tsx
+++ b/test/dom/macros.test.tsx
@@ -164,7 +164,7 @@ describe('macro components', () => {
       useStoryStore.getState().setVariable('items', [1, 2, 3]);
       useStoryStore.getState().setVariable('picked', 0);
       const el = renderPassage(
-        '{for @item of $items}{button $picked = @item}Pick{/button}{/for}',
+        '{for @item of $items}{button "Pick"}{set $picked = @item}{/button}{/for}',
       );
       const buttons = el.querySelectorAll('button.macro-button');
       expect(buttons.length).toBe(3);

--- a/test/dom/render.test.tsx
+++ b/test/dom/render.test.tsx
@@ -151,7 +151,7 @@ describe('renderNodes', () => {
 
     it('appends className to button', () => {
       const el = renderMarkup(
-        '{.danger button $count = $count + 1}Click{/button}',
+        '{.danger button "Click"}$count = $count + 1{/button}',
       );
       const btn = el.querySelector('button');
       expect(btn).not.toBeNull();
@@ -217,7 +217,7 @@ describe('renderNodes', () => {
 
     it('sets id on button', () => {
       const el = renderMarkup(
-        '{#attack button $count = $count + 1}Hit{/button}',
+        '{#attack button "Hit"}$count = $count + 1{/button}',
       );
       const btn = el.querySelector('button');
       expect(btn).not.toBeNull();
@@ -226,7 +226,7 @@ describe('renderNodes', () => {
 
     it('sets id and className on button', () => {
       const el = renderMarkup(
-        '{#attack.danger button $count = $count + 1}Hit{/button}',
+        '{#attack.danger button "Hit"}$count = $count + 1{/button}',
       );
       const btn = el.querySelector('button');
       expect(btn).not.toBeNull();
@@ -261,7 +261,7 @@ describe('renderNodes', () => {
           '{/if}\n' +
           '\n' +
           '{if $health > 0}\n' +
-          '  {.red button $health -= 10}Drink Poison{/button}\n' +
+          '  {.red button "Drink Poison"}$health -= 10{/button}\n' +
           '{/if}',
       );
       // Green span for health status

--- a/test/e2e/global-setup.ts
+++ b/test/e2e/global-setup.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+export default function globalSetup() {
+  const root = resolve(import.meta.dirname!, '../..');
+  execSync('npm run preview', { cwd: root, stdio: 'inherit' });
+}

--- a/test/e2e/story.test.ts
+++ b/test/e2e/story.test.ts
@@ -1526,4 +1526,77 @@ describe('compiled story e2e', () => {
       expect(cond).toBe('true');
     });
   });
+
+  // ===========================================================================
+  // Watch / Trigger system
+  // ===========================================================================
+  describe('Watch / Trigger system', () => {
+    it('watch with dialog fires when condition becomes true', async () => {
+      await navigateFresh();
+      await clickLink('Watch triggers');
+      await page.waitForSelector('[data-passage="Watch Tests"]');
+
+      // Click "Increment watchTest" 3 times to reach threshold
+      for (let i = 0; i < 3; i++) {
+        await page.click('button:has-text("Increment watchTest")');
+      }
+
+      // Dialog should appear
+      await page.waitForSelector('.dialog-overlay');
+      const dialogText = await page.textContent('.dialog-body');
+      expect(dialogText).toContain('watchTest variable reached 3');
+
+      // Close dialog
+      await page.click('.dialog-close');
+      await page.waitForSelector('.dialog-overlay', { state: 'detached' });
+    });
+
+    it('watch with goto navigates when condition becomes true', async () => {
+      await navigateFresh();
+      await clickLink('Watch triggers');
+      await page.waitForSelector('[data-passage="Watch Tests"]');
+
+      await page.click('button:has-text("Set gold to 100")');
+
+      // Should navigate to Watch Goto Result
+      await page.waitForSelector('[data-passage="Watch Goto Result"]');
+      const text = await page.textContent('.passage');
+      expect(text).toContain('reached 100 gold');
+    });
+
+    it('unwatch removes trigger before it fires', async () => {
+      await navigateFresh();
+      await clickLink('Watch triggers');
+      await page.waitForSelector('[data-passage="Watch Tests"]');
+
+      // Unwatch gold trigger first
+      await page.click('button:has-text("Unwatch gold")');
+
+      // Set gold to 100 — should NOT navigate
+      await page.click('button:has-text("Set gold to 100")');
+
+      // Still on Watch Tests passage
+      await page.waitForTimeout(200);
+      const passage = await page.getAttribute('[data-passage]', 'data-passage');
+      expect(passage).toBe('Watch Tests');
+    });
+
+    it('once trigger does not re-fire', async () => {
+      await navigateFresh();
+      await clickLink('Watch triggers');
+      await page.waitForSelector('[data-passage="Watch Tests"]');
+
+      // Trigger the dialog
+      await page.click('button:has-text("Set watchTest to 5")');
+      await page.waitForSelector('.dialog-overlay');
+      await page.click('.dialog-close');
+      await page.waitForSelector('.dialog-overlay', { state: 'detached' });
+
+      // Set watchTest again — no dialog should appear (once trigger self-removed)
+      await page.click('button:has-text("Increment watchTest")');
+      await page.waitForTimeout(200);
+      const overlay = await page.$('.dialog-overlay');
+      expect(overlay).toBeNull();
+    });
+  });
 });

--- a/test/unit/store.test.ts
+++ b/test/unit/store.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useStoryStore } from '../../src/store';
 import { executeStoryInit } from '../../src/story-init';

--- a/test/unit/story-init.test.ts
+++ b/test/unit/story-init.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useStoryStore } from '../../src/store';
 import { executeStoryInit } from '../../src/story-init';

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/e2e/**/*.test.ts'],
+    globalSetup: ['test/e2e/global-setup.ts'],
     testTimeout: 30000,
     hookTimeout: 15000,
   },


### PR DESCRIPTION
## Summary
- **Watch/Unwatch system**: Edge-triggered `{watch}`/`{unwatch}` macros and `Story.watch()`/`Story.unwatch()` JS API for reactive triggers (dialog, goto, run actions)
- **Button convention flip**: Label in opening tag args (with interpolation), executable macros (`{set}`, `{do}`, etc.) in the body
- **Macro-agnostic StoryInit**: Replaced hand-rolled `walkAndExecute` with detached Preact render — any macro (including custom ones) now works in StoryInit
- **E2e auto-build**: Added `globalSetup` to e2e config so `story.html` is always freshly compiled before tests

## Test plan
- [x] 673 unit tests pass
- [x] 186 e2e tests pass (including 4 new watch trigger tests)
- [x] TypeScript compiles cleanly

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)