### PR TITLE
feat: {nobr} macro and [nobr] passage tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable interpolation in CSS selectors on macros and variable display (e.g. `{.{$color} print $msg}`)
 - Interpolation engine (`interpolate()` / `hasInterpolation()`) for resolving `{$var}`, `{_var}`, `{@var}` with dot-path support in string contexts
 - `{include}` macro `inline` flag to render included passage without markdown processing (e.g. `{include "Data" inline}`)
+- `{nobr}...{/nobr}` block macro to suppress `<p>` wrapping while keeping inline markdown
+- `[nobr]` passage tag to suppress `<p>` wrapping for an entire passage
 - Comprehensive e2e test suite covering edge cases (nested macros, widget locals, computed reactivity, timed/repeat macros, form inputs, and more)
 - Unit tests for expression transformer, interpolation engine, option-utils, and tokenizer
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -447,6 +447,24 @@ Add `inline` to skip markdown processing and render the passage content as inlin
 {include "RawData" inline}
 ```
 
+### `{nobr}`
+
+Suppress `<p>` tag generation within a block while keeping inline markdown (bold, italic, etc.).
+
+```
+{nobr}
+**bold** and *italic* — no <p> wrapping
+{/nobr}
+```
+
+Entire passages can be marked with the `[nobr]` tag to achieve the same effect:
+
+```
+:: MyLayout [nobr]
+<div class="sidebar">{include "Nav"}</div>
+<div class="content">{passage}</div>
+```
+
 ### `{widget}`
 
 Define a reusable content block. Optionally declare parameters after the name.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rohal12/spindle",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "A Preact-based story format for Twine 2.",
   "license": "Unlicense",

--- a/src/components/Passage.tsx
+++ b/src/components/Passage.tsx
@@ -9,7 +9,8 @@ import { sourceLocationOf } from '../utils/source-location';
 export function renderPassageContent(passage: PassageData) {
   const tokens = tokenize(passage.content);
   const ast = buildAST(tokens);
-  return renderNodes(ast);
+  const nobr = passage.tags.includes('nobr');
+  return renderNodes(ast, nobr ? { nobr: true } : undefined);
 }
 
 interface PassageProps {

--- a/src/components/macros/Nobr.tsx
+++ b/src/components/macros/Nobr.tsx
@@ -1,0 +1,8 @@
+import { defineMacro } from '../../define-macro';
+
+defineMacro({
+  name: 'nobr',
+  render({ children = [] }, ctx) {
+    return ctx.wrap(ctx.renderNodes(children, { nobr: true }));
+  },
+});

--- a/src/macros/register-builtins.ts
+++ b/src/macros/register-builtins.ts
@@ -20,6 +20,7 @@ import '../components/macros/Dialog';
 import '../components/macros/SaveManager';
 import '../components/macros/SettingsControls';
 import '../components/macros/Include';
+import '../components/macros/Nobr';
 import '../components/macros/Goto';
 import '../components/macros/Unset';
 import '../components/macros/Textbox';

--- a/src/markup/ast.ts
+++ b/src/markup/ast.ts
@@ -54,6 +54,7 @@ const BLOCK_MACROS = new Set([
   'type',
   'widget',
   'span',
+  'nobr',
 ]);
 
 /** Map from branch macro name → required parent macro name */

--- a/src/markup/render.tsx
+++ b/src/markup/render.tsx
@@ -29,9 +29,15 @@ export const LocalsUpdateContext = createContext<LocalsUpdater>(defaultUpdater);
 function htmlToPreact(
   html: string,
   components: preact.ComponentChildren[],
+  nobr = false,
 ): preact.ComponentChildren {
   const temp = document.createElement('div');
   temp.innerHTML = html.trim();
+  if (nobr) {
+    for (const p of Array.from(temp.querySelectorAll(':scope > p'))) {
+      p.replaceWith(...Array.from(p.childNodes));
+    }
+  }
   const children = Array.from(temp.childNodes).map((child, i) =>
     convertDomNode(child, i, components),
   );
@@ -210,7 +216,10 @@ function getVariableTextValue(node: VariableNode): string {
  * After micromark processes the combined string, the HTML is parsed back into
  * Preact VNodes with placeholders replaced by the real rendered components.
  */
-export function renderNodes(nodes: ASTNode[]): preact.ComponentChildren {
+export function renderNodes(
+  nodes: ASTNode[],
+  options?: { nobr?: boolean },
+): preact.ComponentChildren {
   if (nodes.length === 0) return null;
 
   // If there's no text at all, render nodes directly without markdown
@@ -241,5 +250,5 @@ export function renderNodes(nodes: ASTNode[]): preact.ComponentChildren {
   const html = markdownToHtml(combined);
 
   // Convert HTML to Preact VNodes, replacing placeholders with components
-  return htmlToPreact(html, components);
+  return htmlToPreact(html, components, options?.nobr);
 }

--- a/test/dom/macros-extended.test.tsx
+++ b/test/dom/macros-extended.test.tsx
@@ -11,8 +11,13 @@ import {
 import { clearWidgets } from '../../src/widgets/widget-registry';
 import type { StoryData, Passage as PassageData } from '../../src/parser';
 
-function makePassage(pid: number, name: string, content: string): PassageData {
-  return { pid, name, tags: [], metadata: {}, content };
+function makePassage(
+  pid: number,
+  name: string,
+  content: string,
+  tags: string[] = [],
+): PassageData {
+  return { pid, name, tags, metadata: {}, content };
 }
 
 function makeStoryData(passages: PassageData[], startNode = 1): StoryData {
@@ -129,6 +134,32 @@ describe('extended macro components', () => {
       const el = renderPassage('{include "Markdown"}');
       expect(el.querySelector('strong')).not.toBeNull();
       expect(el.querySelector('strong')!.textContent).toBe('bold');
+    });
+  });
+
+  describe('{nobr}', () => {
+    it('suppresses <p> wrapping but keeps inline markdown', () => {
+      const el = renderPassage('{nobr}**bold** text{/nobr}');
+      expect(el.querySelector('p')).toBeNull();
+      expect(el.querySelector('strong')).not.toBeNull();
+      expect(el.textContent).toContain('bold');
+    });
+
+    it('renders <p> tags by default without {nobr}', () => {
+      const el = renderPassage('Some text here');
+      expect(el.querySelector('p')).not.toBeNull();
+    });
+  });
+
+  describe('[nobr] passage tag', () => {
+    it('suppresses <p> wrapping for the entire passage', () => {
+      const passage = makePassage(10, 'NoBr', '**bold** text', ['nobr']);
+      const storyData = makeStoryData([passage], 10);
+      useStoryStore.getState().init(storyData);
+      const container = document.createElement('div');
+      render(<Passage passage={passage} />, container);
+      expect(container.querySelector('p')).toBeNull();
+      expect(container.querySelector('strong')).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `{nobr}...{/nobr}` block macro — suppresses `<p>` tag generation while keeping inline markdown (bold, italic, strikethrough)
- Adds `[nobr]` passage tag — same effect for an entire passage (useful for layout passages like StoryInterface)
- `renderNodes` gains an optional `{ nobr: true }` parameter; `htmlToPreact` unwraps top-level `<p>` elements before converting to VNodes
- Updated docs and changelog, bumped to v0.2.2

## Test plan
- [x] `{nobr}**bold** text{/nobr}` produces `<strong>` but no `<p>`
- [x] Plain text without `{nobr}` still gets `<p>` wrapping
- [x] `[nobr]` passage tag suppresses `<p>` for entire passage
- [x] All 720 tests pass

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)