### PR TITLE
fix: use content-derived keys in {for} macro to prevent stale DOM

### DIFF
--- a/src/components/macros/For.tsx
+++ b/src/components/macros/For.tsx
@@ -137,7 +137,7 @@ defineMacro({
 
       return (
         <ForIteration
-          key={i}
+          key={`${i}-${JSON.stringify(item)}`}
           parentValues={parentValues}
           ownKeys={ownKeys}
           initialValues={{}}

--- a/test/dom/macros.test.tsx
+++ b/test/dom/macros.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from 'preact';
+import { act } from 'preact/test-utils';
 import { Passage } from '../../src/components/Passage';
 import { useStoryStore } from '../../src/store';
 import type { StoryData, Passage as PassageData } from '../../src/parser';
@@ -171,6 +172,36 @@ describe('macro components', () => {
       // Click the second button (item=2)
       (buttons[1] as HTMLElement).click();
       expect(useStoryStore.getState().variables.picked).toBe(2);
+    });
+
+    it('updates items when iterated array identity changes (#45)', () => {
+      useStoryStore.getState().setVariable('items', [
+        ['a', 'b', 'c'],
+        ['x', 'y'],
+      ]);
+      useStoryStore.getState().setVariable('selected', 0);
+      const container = document.createElement('div');
+      const passage = makePassage(
+        1,
+        'Test',
+        '{for @item of $items[$selected]}<span class="item">{@item}</span>{/for}',
+      );
+      act(() => {
+        render(<Passage passage={passage} />, container);
+      });
+      expect(container.querySelectorAll('.item').length).toBe(3);
+      expect(container.textContent).toContain('a');
+      expect(container.textContent).toContain('b');
+      expect(container.textContent).toContain('c');
+
+      // Switch to the second array
+      act(() => {
+        useStoryStore.getState().setVariable('selected', 1);
+      });
+      expect(container.querySelectorAll('.item').length).toBe(2);
+      expect(container.textContent).toContain('x');
+      expect(container.textContent).toContain('y');
+      expect(container.textContent).not.toContain('a');
     });
 
     it('nested for-loops scope @locals correctly with set', () => {


### PR DESCRIPTION
## Summary

- Fixes #45 — `{for}` macro used index-based keys (`key={i}`), causing Preact to reuse `ForIteration` components by position when the iterated array changed. Since `useState` ignores new initial values on reuse, loop variables kept stale values from the previous array.
- Changed key to `` `${i}-${JSON.stringify(item)}` `` so Preact unmounts/remounts when the item at a position changes.
- Added regression test that switches the iterated array and asserts DOM updates correctly.

## Test plan

- [x] New test `updates items when iterated array identity changes (#45)` passes
- [x] All 725 existing tests pass
- [x] `tsc --noEmit` clean

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)