### PR TITLE
feat: :storystartup event, block flag for custom macros (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `:storystartup` DOM event dispatched after Story API installation and author JS execution, but before first render — enables external scripts to register custom macros (including block macros) in time for passage parsing
+- `block` flag on `Story.defineMacro()` to declare custom block macros that accept `{macro}...{/macro}` children; inferred automatically when `subMacros` is provided
 - Configurable passage transitions with outgoing phase support
   - Four transition types: `none` (instant), `fade` (incoming only), `fade-through` (fade out, optional pause, fade in), `crossfade` (simultaneous overlap)
   - `Story.setTransition(config)` sets a persistent default transition

--- a/docs/custom-macros.md
+++ b/docs/custom-macros.md
@@ -47,13 +47,14 @@ Usage: `{shout hello world}` displays **HELLO WORLD**.
 
 ## Block Macros (Children)
 
-If your macro has a closing tag, the content between the tags is available as `props.children`. Use `ctx.renderNodes()` to turn that content into displayable output:
+If your macro has a closing tag, the content between the tags is available as `props.children`. Add `block: true` to your config so the parser knows to expect a closing tag. Use `ctx.renderNodes()` to turn that content into displayable output:
 
 ```
 :: StoryInit
 {do}
   Story.defineMacro({
     name: "alert",
+    block: true,
     render: function(props, ctx) {
       return ctx.h("div", { class: "alert" },
         ctx.renderNodes(props.children || [])
@@ -62,6 +63,8 @@ If your macro has a closing tag, the content between the tags is available as `p
   });
 {/do}
 ```
+
+> **Note:** If you declare `subMacros`, `block` is inferred automatically — you don't need to set it. Use `block: false` to override this if you need sub-macros on a self-closing macro.
 
 Usage:
 
@@ -387,11 +390,12 @@ Usage:
 
 ### Feature Flags
 
-| Flag          | What it adds                                 | Turn it on when...                                    |
-| ------------- | -------------------------------------------- | ----------------------------------------------------- |
-| `interpolate` | `ctx.resolve(s)` — resolve variable refs     | Authors may use `{$var}` in class names or IDs        |
-| `merged`      | `ctx.evaluate(expr)` — evaluate expressions  | Your macro needs to read variables or run expressions |
-| `storeVar`    | `ctx.varName`, `ctx.value`, `ctx.setValue()` | Your macro is an input bound to a single `$variable`  |
+| Flag          | What it adds                                 | Turn it on when...                                         |
+| ------------- | -------------------------------------------- | ---------------------------------------------------------- |
+| `block`       | Closing-tag support (`{macro}...{/macro}`)   | Your macro wraps content (auto-set when `subMacros` given) |
+| `interpolate` | `ctx.resolve(s)` — resolve variable refs     | Authors may use `{$var}` in class names or IDs             |
+| `merged`      | `ctx.evaluate(expr)` — evaluate expressions  | Your macro needs to read variables or run expressions      |
+| `storeVar`    | `ctx.varName`, `ctx.value`, `ctx.setValue()` | Your macro is an input bound to a single `$variable`       |
 
 ### Variable Namespaces
 

--- a/docs/story-api.md
+++ b/docs/story-api.md
@@ -141,14 +141,15 @@ Returns `true` if a quick save exists for the current session.
 
 Register a custom macro. See [Custom Macros](custom-macros.md) for full details.
 
-| Property      | Type        | Description                                                         |
-| ------------- | ----------- | ------------------------------------------------------------------- |
-| `name`        | `string`    | Macro name (case-insensitive)                                       |
-| `interpolate` | `boolean?`  | Resolve variable interpolations in className/id                     |
-| `merged`      | `boolean?`  | Provide `ctx.merged` variable 3-tuple + `ctx.evaluate()`            |
-| `storeVar`    | `boolean?`  | Bind to a `$variable`: `ctx.varName`, `ctx.value`, `ctx.setValue()` |
-| `subMacros`   | `string[]?` | Register sub-macro names for branching                              |
-| `render`      | `function`  | `(props, ctx) => VNode \| null` — the render function               |
+| Property      | Type        | Description                                                                    |
+| ------------- | ----------- | ------------------------------------------------------------------------------ |
+| `name`        | `string`    | Macro name (case-insensitive)                                                  |
+| `block`       | `boolean?`  | Declare as block macro (`{macro}...{/macro}`). Auto-set when `subMacros` given |
+| `interpolate` | `boolean?`  | Resolve variable interpolations in className/id                                |
+| `merged`      | `boolean?`  | Provide `ctx.merged` variable 3-tuple + `ctx.evaluate()`                       |
+| `storeVar`    | `boolean?`  | Bind to a `$variable`: `ctx.varName`, `ctx.value`, `ctx.setValue()`            |
+| `subMacros`   | `string[]?` | Register sub-macro names for branching                                         |
+| `render`      | `function`  | `(props, ctx) => VNode \| null` — the render function                          |
 
 ```
 {do}
@@ -449,6 +450,27 @@ Returns a random integer between `min` and `max` (inclusive).
 PRNG state is automatically saved and restored. After loading a save, the random sequence continues from exactly where it was when the save was made. History navigation (back/forward) also restores the PRNG state from that point in the story.
 
 ## Events
+
+### `:storystartup`
+
+A DOM event dispatched on `document` after the Story API is installed and author JavaScript has executed, but **before** passages are parsed or rendered. This is the right place for external scripts to register custom macros (including block macros) so they are available at parse time.
+
+```js
+document.addEventListener(':storystartup', function () {
+  Story.defineMacro({
+    name: 'choices',
+    block: true,
+    subMacros: ['choice'],
+    render: function (props, ctx) {
+      /* ... */
+    },
+  });
+});
+```
+
+::: tip
+You don't need `:storystartup` for macros defined in the story JavaScript (the `:: StoryScript` passage) — those run synchronously before `:storystartup` fires and before passages are parsed. The event is for **external scripts** loaded independently from the story format.
+:::
 
 ### `:storyready`
 

--- a/docs/superpowers/specs/2026-03-20-storystartup-event-design.md
+++ b/docs/superpowers/specs/2026-03-20-storystartup-event-design.md
@@ -1,0 +1,51 @@
+# `:storystartup` Event & Dynamic Block Macro Registration
+
+**Issue:** [#47](https://github.com/rohal12/spindle/issues/47)
+**Date:** 2026-03-20
+
+## Problem
+
+`Story.defineMacro()` is the public API for registering custom macros, but there is no event that fires between Story API installation and the first passage render. The only event, `:storyready`, fires after `render(<App />)` — too late for block macros that must be known by the AST builder at parse time.
+
+Additionally, `BLOCK_MACROS` in `ast.ts` is a hardcoded `Set` with no public API to add entries. Even if timing were fixed, `defineMacro()` with `subMacros` would not register the parent as a block macro, causing the AST builder to treat it as self-closing.
+
+## Design
+
+### 1. Dynamic block macro registration (`ast.ts`)
+
+Export `registerBlockMacro(name: string)` that adds to the existing `BLOCK_MACROS` set. No changes to `BRANCH_PARENT` or `BRANCHING_BLOCK_MACROS` — those are built-in-only patterns.
+
+### 2. `block` flag on `MacroDefinition` (`define-macro.ts`)
+
+Add `block?: boolean` to `MacroDefinition`. In `defineMacro()`, after registering the macro and sub-macros, call `registerBlockMacro(name)` when:
+
+- `config.block === true`, OR
+- `config.subMacros` is a non-empty array and `config.block !== false`
+
+### 3. `:storystartup` event (`index.tsx`)
+
+Dispatch `new CustomEvent(':storystartup')` after author JS execution (after line 68 in current `boot()`) but before passage validation, store init, and render. External scripts can listen for this event to register block macros in time.
+
+### 4. Boot sequence (updated)
+
+1. `parseStoryData()`
+2. Inject built-in styles
+3. `installStoryAPI()` — `window.Story` available
+4. Apply author CSS
+5. Execute author JavaScript (can call `Story.defineMacro()` synchronously)
+6. **Dispatch `:storystartup`** — external scripts register macros here
+7. Validate StoryVariables and passages
+8. Initialize store
+9. `executeStoryInit()`
+10. Restore session
+11. Register widgets
+12. Setup subscriptions
+13. Render App
+14. Dispatch `:storyready`
+
+## Files Changed
+
+- `src/markup/ast.ts` — export `registerBlockMacro()`
+- `src/define-macro.ts` — add `block` flag, call `registerBlockMacro` when appropriate
+- `src/index.tsx` — dispatch `:storystartup` after author JS
+- `src/story-api.ts` — update `StoryAPI` type to document `block` field

--- a/src/define-macro.ts
+++ b/src/define-macro.ts
@@ -28,6 +28,7 @@ import { currentSourceLocation } from './utils/source-location';
 import { parseVarArgs, extractOptions } from './components/macros/option-utils';
 import { registerMacro, registerSubMacro } from './registry';
 import type { MacroProps } from './registry';
+import { registerBlockMacro } from './markup/ast';
 
 export function macroClass(type: string, className?: string): string {
   const base = `macro-${type}`;
@@ -74,6 +75,7 @@ export interface MacroContext {
 export interface MacroDefinition {
   name: string;
   subMacros?: string[];
+  block?: boolean;
   interpolate?: boolean;
   merged?: boolean;
   storeVar?: boolean;
@@ -157,5 +159,11 @@ export function defineMacro(config: MacroDefinition): void {
   registerMacro(config.name, Wrapper);
   if (config.subMacros) {
     for (const sub of config.subMacros) registerSubMacro(sub);
+  }
+  if (
+    config.block === true ||
+    (config.block !== false && config.subMacros && config.subMacros.length > 0)
+  ) {
+    registerBlockMacro(config.name);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,6 +67,10 @@ function boot() {
     }
   }
 
+  // Signal that Story API is ready and author JS has run.
+  // External scripts can register custom macros (including block macros) here.
+  document.dispatchEvent(new CustomEvent(':storystartup'));
+
   // Parse StoryVariables and validate all passages
   let defaults: Record<string, unknown> = {};
   const storyVarsPassage = storyData.passages.get('StoryVariables');

--- a/src/markup/ast.ts
+++ b/src/markup/ast.ts
@@ -57,6 +57,16 @@ const BLOCK_MACROS = new Set([
   'nobr',
 ]);
 
+/** Register a custom macro as a block macro so the AST builder nests children. */
+export function registerBlockMacro(name: string): void {
+  BLOCK_MACROS.add(name.toLowerCase());
+}
+
+/** Unregister a custom block macro (for test cleanup). */
+export function unregisterBlockMacro(name: string): void {
+  BLOCK_MACROS.delete(name.toLowerCase());
+}
+
 /** Map from branch macro name → required parent macro name */
 const BRANCH_PARENT: Record<string, string> = {
   elseif: 'if',

--- a/test/unit/define-macro-block.test.ts
+++ b/test/unit/define-macro-block.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { tokenize } from '../../src/markup/tokenizer';
+import {
+  buildAST,
+  registerBlockMacro,
+  unregisterBlockMacro,
+  type MacroNode,
+} from '../../src/markup/ast';
+import { defineMacro } from '../../src/define-macro';
+import { getMacro, isSubMacro } from '../../src/registry';
+
+function parse(input: string) {
+  return buildAST(tokenize(input));
+}
+
+describe('registerBlockMacro', () => {
+  afterEach(() => {
+    unregisterBlockMacro('custom');
+    unregisterBlockMacro('choices');
+  });
+
+  it('makes the AST builder treat the macro as a block', () => {
+    registerBlockMacro('custom');
+    const ast = parse('{custom}hello{/custom}');
+    expect(ast).toHaveLength(1);
+    const node = ast[0] as MacroNode;
+    expect(node.type).toBe('macro');
+    expect(node.name).toBe('custom');
+    expect(node.children).toEqual([{ type: 'text', value: 'hello' }]);
+  });
+
+  it('without registration, closing tag throws', () => {
+    expect(() => parse('{choices}pick one{/choices}')).toThrow(
+      'Unexpected closing {/choices}',
+    );
+  });
+});
+
+describe('defineMacro with block flag', () => {
+  afterEach(() => {
+    unregisterBlockMacro('panel');
+    unregisterBlockMacro('accordion');
+    unregisterBlockMacro('choices');
+  });
+
+  it('block: true registers the macro as a block macro', () => {
+    defineMacro({
+      name: 'panel',
+      block: true,
+      render: () => null,
+    });
+
+    expect(getMacro('panel')).toBeDefined();
+    const ast = parse('{panel}content{/panel}');
+    const node = ast[0] as MacroNode;
+    expect(node.name).toBe('panel');
+    expect(node.children).toEqual([{ type: 'text', value: 'content' }]);
+  });
+
+  it('subMacros implies block registration', () => {
+    defineMacro({
+      name: 'choices',
+      subMacros: ['choice'],
+      render: () => null,
+    });
+
+    expect(getMacro('choices')).toBeDefined();
+    expect(isSubMacro('choice')).toBe(true);
+    const ast = parse('{choices}pick{/choices}');
+    const node = ast[0] as MacroNode;
+    expect(node.name).toBe('choices');
+    expect(node.children).toEqual([{ type: 'text', value: 'pick' }]);
+  });
+
+  it('subMacros with block: false does NOT register as block', () => {
+    defineMacro({
+      name: 'accordion',
+      subMacros: ['section'],
+      block: false,
+      render: () => null,
+    });
+
+    expect(getMacro('accordion')).toBeDefined();
+    expect(isSubMacro('section')).toBe(true);
+    // Should be treated as self-closing since block: false
+    expect(() => parse('{accordion}content{/accordion}')).toThrow(
+      'Unexpected closing {/accordion}',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Dispatch `:storystartup` DOM event after Story API installation and author JS execution, but before first render — gives external scripts a hook to register custom macros in time for passage parsing
- Add `block` flag to `MacroDefinition` so `defineMacro()` can declare block macros (`{macro}...{/macro}`) at runtime via `registerBlockMacro()`
- `block` is inferred automatically when `subMacros` is provided (opt out with `block: false`)

Closes #47

## Changes

| File | Change |
|------|--------|
| `src/markup/ast.ts` | Export `registerBlockMacro()` / `unregisterBlockMacro()` |
| `src/define-macro.ts` | Add `block?: boolean` to `MacroDefinition`, call `registerBlockMacro` when appropriate |
| `src/index.tsx` | Dispatch `:storystartup` after author JS, before validation/render |
| `test/unit/define-macro-block.test.ts` | 5 new tests for dynamic block registration and `block` flag |
| `CHANGELOG.md` | Document new features |
| `docs/story-api.md` | Add `block` field to `defineMacro` table, document `:storystartup` event |
| `docs/custom-macros.md` | Add `block: true` to block macro example, add to feature flags table |

## Test plan

- [x] 5 new unit tests pass (`registerBlockMacro`, `defineMacro` with `block: true`, `subMacros` inference, `block: false` override)
- [x] All 730 existing tests pass
- [x] TypeScript type-check clean (`tsc --noEmit`)

release-npm