### PR TITLE
fix: normalize macro names to lowercase in AST builder (#49)

### DIFF
--- a/src/markup/ast.ts
+++ b/src/markup/ast.ts
@@ -179,6 +179,10 @@ export function buildAST(tokens: Token[]): ASTNode[] {
       }
 
       case 'macro': {
+        // Normalize macro name to lowercase — registration is lowercase,
+        // but the tokenizer preserves original casing from passage markup.
+        const name = token.name.toLowerCase();
+
         if (token.isClose) {
           // Closing tag — pop from stack
           if (stack.length === 0) {
@@ -188,7 +192,7 @@ export function buildAST(tokens: Token[]): ASTNode[] {
           }
 
           const top = stack[stack.length - 1]!;
-          if (top.node.type !== 'macro' || top.node.name !== token.name) {
+          if (top.node.type !== 'macro' || top.node.name !== name) {
             const expected =
               top.node.type === 'macro'
                 ? `{/${top.node.name}}`
@@ -204,8 +208,8 @@ export function buildAST(tokens: Token[]): ASTNode[] {
         }
 
         // Handle branch macros (elseif/else, case/default, next)
-        if (BRANCH_PARENT[token.name]) {
-          const expectedParent = BRANCH_PARENT[token.name]!;
+        if (BRANCH_PARENT[name]) {
+          const expectedParent = BRANCH_PARENT[name]!;
           const topNode =
             stack.length > 0 ? stack[stack.length - 1]!.node : null;
           if (
@@ -229,16 +233,16 @@ export function buildAST(tokens: Token[]): ASTNode[] {
         }
 
         // Block macro — push onto stack
-        if (BLOCK_MACROS.has(token.name)) {
+        if (BLOCK_MACROS.has(name)) {
           const node: MacroNode = {
             type: 'macro',
-            name: token.name,
+            name,
             rawArgs: token.rawArgs,
             children: [],
           };
 
           // Branching blocks: className/id goes on the first branch, not the node
-          if (BRANCHING_BLOCK_MACROS.has(token.name)) {
+          if (BRANCHING_BLOCK_MACROS.has(name)) {
             const firstBranch: Branch = {
               rawArgs: token.rawArgs,
               children: [],
@@ -259,7 +263,7 @@ export function buildAST(tokens: Token[]): ASTNode[] {
         {
           const macroNode: MacroNode = {
             type: 'macro',
-            name: token.name,
+            name,
             rawArgs: token.rawArgs,
             children: [],
           };

--- a/test/unit/ast.test.ts
+++ b/test/unit/ast.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { tokenize } from '../../src/markup/tokenizer';
-import { buildAST, type ASTNode, type MacroNode } from '../../src/markup/ast';
+import {
+  buildAST,
+  registerBlockMacro,
+  unregisterBlockMacro,
+  type ASTNode,
+  type MacroNode,
+} from '../../src/markup/ast';
 
 function parse(input: string): ASTNode[] {
   return buildAST(tokenize(input));
@@ -517,6 +523,60 @@ describe('buildAST', () => {
       const repeat = ast[0] as MacroNode;
       expect(repeat.children).toHaveLength(2);
       expect((repeat.children[1] as MacroNode).name).toBe('stop');
+    });
+  });
+
+  describe('case-insensitive macro names', () => {
+    it('recognizes built-in block macros regardless of case', () => {
+      const ast = parse('{If $x}hello{/If}');
+      expect(ast).toHaveLength(1);
+      const node = ast[0] as MacroNode;
+      expect(node.type).toBe('macro');
+      expect(node.name).toBe('if');
+      expect(node.branches).toHaveLength(1);
+      expect(node.branches![0].children).toEqual([
+        { type: 'text', value: 'hello' },
+      ]);
+    });
+
+    it('recognizes custom block macros regardless of case', () => {
+      registerBlockMacro('choices');
+      try {
+        const ast = parse('{Choices}hello{/Choices}');
+        expect(ast).toHaveLength(1);
+        const node = ast[0] as MacroNode;
+        expect(node.type).toBe('macro');
+        expect(node.name).toBe('choices');
+        expect(node.children).toEqual([{ type: 'text', value: 'hello' }]);
+      } finally {
+        unregisterBlockMacro('choices');
+      }
+    });
+
+    it('matches closing tag case-insensitively', () => {
+      const ast = parse('{FOR @item of $list}item{/for}');
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('for');
+      expect(node.children).toEqual([{ type: 'text', value: 'item' }]);
+    });
+
+    it('matches branch macro parents case-insensitively', () => {
+      const ast = parse('{IF $a}A{elseif $b}B{ELSE}C{/if}');
+      const node = ast[0] as MacroNode;
+      expect(node.branches).toHaveLength(3);
+    });
+
+    it('lowercases macro name in AST nodes', () => {
+      const ast = parse('{SET $x = 5}');
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('set');
+    });
+
+    it('recognizes branching block macros regardless of case', () => {
+      const ast = parse('{Switch $x}{case 1}one{/Switch}');
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('switch');
+      expect(node.branches).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
## Summary

- Normalize `token.name` to lowercase at the entry of the macro case in `buildAST()`, so all lookups (block macro set, branch parent map, branching block set, closing tag match) and stored AST node names are consistent with the lowercased registration.
- Fixes `{Choices}...{/Choices}` failing with "Unexpected closing {/Choices}" when the macro was registered as `"choices"`.
- Adds 6 tests covering case-insensitive block macros, closing tags, branch parents, self-closing macros, and custom block macros.

Closes #49

## Test plan

- [x] All 6 new case-insensitive tests pass
- [x] All 736 existing tests pass
- [x] `tsc --noEmit` clean

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)