### PR TITLE
fix: preserve HTML tags in passage content for button macro

### DIFF
--- a/dev/story.twee
+++ b/dev/story.twee
@@ -47,6 +47,7 @@ $done_count = 0
 $ready_conditional = false
 $watchTest = 0
 $watchGold = 0
+$btnHtmlResult = ""
 
 
 :: StoryInit
@@ -103,7 +104,7 @@ A wooden door stands to the north. Through a crack beneath it, you see flickerin
 
 [[Code passages->Code Passages Test]] | [[Watch triggers->Watch Tests]] | [[Dialog API->Dialog API Tests]] | [[SVG test->SVG Interop]]
 
-[[Nested HTML include->Nested HTML Include Test]]
+[[Nested HTML include->Nested HTML Include Test]] | [[Button HTML test->Button HTML Test]]
 
 :: Hallway
 {set $visited_rooms = $visited_rooms + 1}
@@ -1257,3 +1258,12 @@ This is a programmatic dialog. It was opened via Story.openDialog().
 
 :: Dialog API Second
 This is the second queued dialog.
+
+:: Button HTML Test
+**Button with HTML block element inside:**
+
+{button}<div class="nav-item">Click me</div>{set $btnHtmlResult = "div-clicked"}{/button}
+
+Result: {$btnHtmlResult}
+
+[[Start]]

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,9 +19,24 @@ export interface StoryData {
 }
 
 /**
+ * Decode the HTML entities that browsers use when serializing innerHTML.
+ * &amp; is decoded last to avoid double-decoding (e.g. &amp;lt; → &lt;, not <).
+ */
+function decodeHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
  * Parse <tw-storydata> and all <tw-passagedata> elements from the DOM.
- * The browser auto-decodes HTML entities when building the DOM, so
- * textContent gives us the original passage text.
+ *
+ * Uses innerHTML + entity decoding instead of textContent so that HTML
+ * tags inside passage markup (e.g. <div> inside {button}) are preserved
+ * regardless of whether the compiler HTML-encoded them.
  */
 export function parseStoryData(): StoryData {
   const storyEl = document.querySelector('tw-storydata');
@@ -52,7 +67,7 @@ export function parseStoryData(): StoryData {
     const tags = (el.getAttribute('tags') || '')
       .split(/\s+/)
       .filter((t) => t.length > 0);
-    const content = el.textContent || '';
+    const content = decodeHtmlEntities(el.innerHTML);
 
     const metadata: Record<string, string> = {};
     const skipAttrs = new Set(['pid', 'name', 'tags']);

--- a/test/dom/parser.test.ts
+++ b/test/dom/parser.test.ts
@@ -116,6 +116,31 @@ describe('parseStoryData', () => {
     expect(data.passages.get('Start')!.tags).toEqual([]);
   });
 
+  it('preserves HTML tags in passage content when HTML-encoded', () => {
+    setDocumentHTML(`
+      <tw-storydata name="Test" startnode="1" ifid="X" format="" format-version="">
+        <tw-passagedata pid="1" name="Start" tags="">{button}&lt;div class=&quot;nav-item&quot;&gt;Click me&lt;/div&gt;{set $myVar = &quot;clicked&quot;}{/button}</tw-passagedata>
+      </tw-storydata>
+    `);
+    const data = parseStoryData();
+    expect(data.passages.get('Start')!.content).toBe(
+      '{button}<div class="nav-item">Click me</div>{set $myVar = "clicked"}{/button}',
+    );
+  });
+
+  it('preserves HTML tags in passage content when NOT HTML-encoded', () => {
+    setDocumentHTML(`
+      <tw-storydata name="Test" startnode="1" ifid="X" format="" format-version="">
+        <tw-passagedata pid="1" name="Start" tags="">{button}<div class="nav-item">Click me</div>{set $myVar = "clicked"}{/button}</tw-passagedata>
+      </tw-storydata>
+    `);
+    const data = parseStoryData();
+    // The <div> should be preserved as literal text for the tokenizer
+    expect(data.passages.get('Start')!.content).toBe(
+      '{button}<div class="nav-item">Click me</div>{set $myVar = "clicked"}{/button}',
+    );
+  });
+
   it('makes passages accessible by both name and pid', () => {
     setDocumentHTML(MINIMAL_STORY);
     const data = parseStoryData();

--- a/test/e2e/issue60.test.ts
+++ b/test/e2e/issue60.test.ts
@@ -1,0 +1,125 @@
+/**
+ * E2E reproduction test for issue #60:
+ * {button} macro fails to parse when body contains HTML block elements.
+ *
+ * Requires dist/story.html to exist (run `npm run preview` first).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { createServer } from 'http';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, extname } from 'path';
+
+const projectRoot = resolve(import.meta.dirname!, '../..');
+const distDir = resolve(projectRoot, 'dist');
+const storyPath = resolve(distDir, 'story.html');
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+};
+
+let server: ReturnType<typeof createServer>;
+let browser: Browser;
+let page: Page;
+let baseUrl: string;
+
+beforeAll(async () => {
+  if (!existsSync(storyPath)) {
+    throw new Error('dist/story.html not found. Run `npm run preview` first.');
+  }
+
+  server = createServer((req, res) => {
+    const filePath = resolve(
+      distDir,
+      (req.url || '/').replace(/^\//, '') || 'story.html',
+    );
+    if (!existsSync(filePath)) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const ext = extname(filePath);
+    res.writeHead(200, {
+      'Content-Type': MIME[ext] || 'application/octet-stream',
+    });
+    res.end(readFileSync(filePath));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+
+  browser = await chromium.launch();
+  page = await browser.newPage();
+}, 30_000);
+
+afterAll(async () => {
+  await browser?.close();
+  server?.close();
+});
+
+describe('issue #60: button with HTML block elements', () => {
+  it('renders button passage without parse errors', async () => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto(`${baseUrl}/story.html`);
+    await page.waitForSelector('[data-passage="Start"]');
+    await page.click('a.macro-link:has-text("Button HTML test")');
+    await page.waitForSelector('[data-passage="Button HTML Test"]');
+
+    // No parse errors should have occurred
+    const errorDivs = await page.$$('.passage .error');
+    const errorTexts = await Promise.all(
+      errorDivs.map((el) => el.textContent()),
+    );
+    expect(
+      errorTexts.filter(
+        (t) => t?.includes('Expected') || t?.includes('Unexpected'),
+      ),
+    ).toHaveLength(0);
+
+    // The button should be rendered
+    const button = await page.$('button.macro-button');
+    expect(button).not.toBeNull();
+
+    // No JS errors related to parsing
+    expect(
+      pageErrors.filter(
+        (e) => e.includes('Expected') || e.includes('Unexpected'),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('button click does not throw errors', async () => {
+    const pageErrors: string[] = [];
+
+    const testPage = await browser.newPage();
+    testPage.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await testPage.goto(`${baseUrl}/story.html`);
+    await testPage.waitForSelector('[data-passage="Start"]');
+    await testPage.click('a.macro-link:has-text("Button HTML test")');
+    await testPage.waitForSelector('[data-passage="Button HTML Test"]');
+
+    // Click the button — should not throw
+    await testPage.click('button.macro-button');
+
+    // Brief pause for any async errors to surface
+    await testPage.waitForTimeout(500);
+
+    expect(
+      pageErrors.filter(
+        (e) => e.includes('Expected') || e.includes('Unexpected'),
+      ),
+    ).toHaveLength(0);
+
+    await testPage.close();
+  });
+});

--- a/test/unit/ast.test.ts
+++ b/test/unit/ast.test.ts
@@ -657,6 +657,45 @@ describe('buildAST', () => {
     });
   });
 
+  describe('issue #60: button with HTML block elements', () => {
+    it('parses {button} with <div> inside body', () => {
+      const ast = parse(
+        '{button}<div class="nav-item">Click me</div>{set $myVar = "clicked"}{/button}',
+      );
+      expect(ast).toHaveLength(1);
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('button');
+      expect(node.children).toHaveLength(2);
+      expect(node.children[0].type).toBe('html');
+      expect((node.children[0] as any).tag).toBe('div');
+      expect((node.children[1] as MacroNode).name).toBe('set');
+    });
+
+    it('parses {button} with nested divs', () => {
+      const ast = parse(
+        '{button}<div class="outer"><div class="inner">Content</div></div>{/button}',
+      );
+      expect(ast).toHaveLength(1);
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('button');
+      expect(node.children).toHaveLength(1);
+      const outer = node.children[0] as any;
+      expect(outer.tag).toBe('div');
+      expect(outer.children).toHaveLength(1);
+      expect(outer.children[0].tag).toBe('div');
+    });
+
+    it('parses {button} with text only (no HTML)', () => {
+      const ast = parse('{button}Click me{set $myVar = "clicked"}{/button}');
+      expect(ast).toHaveLength(1);
+      const node = ast[0] as MacroNode;
+      expect(node.name).toBe('button');
+      expect(node.children).toHaveLength(2);
+      expect(node.children[0].type).toBe('text');
+      expect((node.children[1] as MacroNode).name).toBe('set');
+    });
+  });
+
   describe('mixed content', () => {
     it('handles complete passage with macros and links', () => {
       const ast = parse('Hello {$name}! {set $seen = true}\n[[Next]]');


### PR DESCRIPTION
## Summary

- **Root cause:** `parseStoryData()` used `el.textContent` to extract passage content from `<tw-passagedata>` elements. When a compiler doesn't HTML-encode the content, the browser's DOM parser treats `<div>` (and other HTML tags) as real elements, and `textContent` silently strips them — losing the HTML markup that the tokenizer needs.
- **Fix:** Switch to `el.innerHTML` with a lightweight entity decoder (`&lt;` → `<`, etc.) so HTML tags inside macro bodies are preserved regardless of whether the compiler HTML-encodes them.

Closes #60

## Test plan

- [x] Unit test: `{button}` with `<div>` inside body parses correctly (AST test)
- [x] Unit test: `{button}` with nested divs parses correctly
- [x] DOM test: HTML-encoded passage content preserves tags
- [x] DOM test: Non-HTML-encoded passage content preserves tags (was failing before fix)
- [x] E2E test: Button with HTML block element renders without parse errors
- [x] E2E test: Button click does not throw errors
- [x] All 776 unit/DOM tests pass
- [x] All 203 e2e tests pass
- [x] TypeScript type check passes