### PR TITLE
fix: wire slot parameter through save/load/hasSave (#96)

### DIFF
--- a/docs/story-api.md
+++ b/docs/story-api.md
@@ -174,17 +174,32 @@ Set a one-shot transition for the next navigation only. Consumed automatically w
 {/do}
 ```
 
-### `Story.save()`
+### `Story.save(slot?)`
 
-Perform a quick save.
+Perform a quick save. When `slot` is provided, saves to a named slot instead of the default autosave slot.
 
-### `Story.load()`
+```javascript
+Story.save(); // save to default slot
+Story.save('my-slot'); // save to named slot
+```
 
-Load the quick save.
+### `Story.load(slot?)`
 
-### `Story.hasSave()`
+Load a saved game. When `slot` is provided, loads from the named slot.
 
-Returns `true` if a quick save exists for the current session.
+```javascript
+Story.load(); // load from default slot
+Story.load('my-slot'); // load from named slot
+```
+
+### `Story.hasSave(slot?)`
+
+Returns `true` if a save exists for the given slot. Checks actual storage (persists across page reloads).
+
+```javascript
+Story.hasSave(); // check default slot
+Story.hasSave('my-slot'); // check named slot
+```
 
 ### `Story.defineMacro(config)`
 

--- a/src/components/macros/MenubarButtons.tsx
+++ b/src/components/macros/MenubarButtons.tsx
@@ -119,7 +119,7 @@ defineMenubarAction({
   setup: () => {
     const load = useStoryStore((s) => s.load);
     const hasSave = useStoryStore((s) => s.hasSave);
-    useStoryStore((s) => s.saveVersion);
+    useStoryStore((s) => s.knownSaves);
     return { perform: () => load(), disabled: !hasSave() };
   },
 });

--- a/src/saves/save-manager.ts
+++ b/src/saves/save-manager.ts
@@ -258,16 +258,25 @@ export async function getSavesGrouped(
   return result;
 }
 
-// --- Quick Save ---
+// --- Quick Save / Slot Save ---
 
 const AUTOSAVE_KEY_PREFIX = 'autosave.';
+const SLOT_KEY_PREFIX = 'slot.';
+const SLOT_INDEX_KEY_PREFIX = 'slotIndex.';
+
+function slotMetaKey(ifid: string, slot?: string): string {
+  return slot != null
+    ? `${SLOT_KEY_PREFIX}${slot}.${ifid}`
+    : `${AUTOSAVE_KEY_PREFIX}${ifid}`;
+}
 
 export async function quickSave(
   ifid: string,
   playthroughId: string,
   payload: SavePayload,
+  slot?: string,
 ): Promise<SaveRecord> {
-  const metaKey = `${AUTOSAVE_KEY_PREFIX}${ifid}`;
+  const metaKey = slotMetaKey(ifid, slot);
   const existingId = await getMeta<string>(metaKey);
 
   if (existingId) {
@@ -275,16 +284,30 @@ export async function quickSave(
     if (updated) return updated;
   }
 
-  // Create new autosave
+  // Create new save
   const record = await createSave(ifid, playthroughId, payload, {
-    isAutosave: true,
+    isAutosave: !slot,
+    ...(slot != null ? { slot } : {}),
   });
   await setMeta(metaKey, record.meta.id);
+
+  // Track named slots in the index
+  if (slot != null) {
+    const indexKey = `${SLOT_INDEX_KEY_PREFIX}${ifid}`;
+    const existing = (await getMeta<string[]>(indexKey)) ?? [];
+    if (!existing.includes(slot)) {
+      await setMeta(indexKey, [...existing, slot]);
+    }
+  }
+
   return record;
 }
 
-export async function hasQuickSave(ifid: string): Promise<boolean> {
-  const metaKey = `${AUTOSAVE_KEY_PREFIX}${ifid}`;
+export async function hasQuickSave(
+  ifid: string,
+  slot?: string,
+): Promise<boolean> {
+  const metaKey = slotMetaKey(ifid, slot);
   const existingId = await getMeta<string>(metaKey);
   if (!existingId) return false;
   const record = await getSave(existingId);
@@ -293,11 +316,38 @@ export async function hasQuickSave(ifid: string): Promise<boolean> {
 
 export async function loadQuickSave(
   ifid: string,
+  slot?: string,
 ): Promise<SavePayload | undefined> {
-  const metaKey = `${AUTOSAVE_KEY_PREFIX}${ifid}`;
+  const metaKey = slotMetaKey(ifid, slot);
   const existingId = await getMeta<string>(metaKey);
   if (!existingId) return undefined;
   return loadSave(existingId);
+}
+
+/**
+ * Check IDB for all known saves and return a map of slot keys to true.
+ * The default (autosave) slot uses empty string as key.
+ */
+export async function populateKnownSaves(
+  ifid: string,
+): Promise<Record<string, true>> {
+  const result: Record<string, true> = {};
+
+  // Check default autosave
+  if (await hasQuickSave(ifid)) {
+    result[''] = true;
+  }
+
+  // Check named slots from the index
+  const indexKey = `${SLOT_INDEX_KEY_PREFIX}${ifid}`;
+  const slots = (await getMeta<string[]>(indexKey)) ?? [];
+  for (const slot of slots) {
+    if (await hasQuickSave(ifid, slot)) {
+      result[slot] = true;
+    }
+  }
+
+  return result;
 }
 
 // --- Session Persistence (survives F5, cleared on tab close) ---

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,7 @@ import {
   getCurrentPlaythroughId,
   quickSave,
   loadQuickSave,
+  populateKnownSaves,
   saveSession,
   clearSession,
 } from './saves/save-manager';
@@ -198,7 +199,7 @@ export interface StoryState {
   historyIndex: number;
   visitCounts: Record<string, number>;
   renderCounts: Record<string, number>;
-  saveVersion: number;
+  knownSaves: Record<string, true>;
   playthroughId: string;
   maxHistory: number;
   saveError: string | null;
@@ -243,7 +244,7 @@ export const useStoryStore = create<StoryState>()(
     historyIndex: -1,
     visitCounts: {},
     renderCounts: {},
-    saveVersion: 0,
+    knownSaves: {},
     playthroughId: '',
     maxHistory: 40,
     saveError: null,
@@ -305,6 +306,14 @@ export const useStoryStore = create<StoryState>()(
             const newId = await startNewPlaythrough(ifid);
             set((state) => {
               state.playthroughId = newId;
+            });
+          }
+
+          // Populate knownSaves from IDB so hasSave() works after reload
+          const saves = await populateKnownSaves(ifid);
+          if (Object.keys(saves).length > 0) {
+            set((state) => {
+              state.knownSaves = saves;
             });
           }
         })
@@ -487,7 +496,7 @@ export const useStoryStore = create<StoryState>()(
         );
     },
 
-    save: () => {
+    save: (slot?: string) => {
       const { storyData, playthroughId } = get();
       if (!storyData) return;
 
@@ -496,14 +505,17 @@ export const useStoryStore = create<StoryState>()(
       set((state) => {
         state.saveError = null;
       });
-      quickSave(storyData.ifid, playthroughId, payload)
+      quickSave(storyData.ifid, playthroughId, payload, slot)
         .then(() => {
           set((state) => {
-            state.saveVersion++;
+            state.knownSaves = {
+              ...state.knownSaves,
+              [slot ?? '']: true,
+            };
           });
         })
         .catch((err) => {
-          console.error('spindle: failed to quick save', err);
+          console.error('spindle: failed to save', err);
           set((state) => {
             state.saveError =
               err instanceof Error ? err.message : 'Failed to save';
@@ -511,20 +523,20 @@ export const useStoryStore = create<StoryState>()(
         });
     },
 
-    load: () => {
+    load: (slot?: string) => {
       const { storyData } = get();
       if (!storyData) return;
 
       set((state) => {
         state.loadError = null;
       });
-      loadQuickSave(storyData.ifid)
+      loadQuickSave(storyData.ifid, slot)
         .then((payload) => {
           if (!payload) return;
           get().loadFromPayload(payload);
         })
         .catch((err) => {
-          console.error('spindle: failed to load quick save', err);
+          console.error('spindle: failed to load save', err);
           set((state) => {
             state.loadError =
               err instanceof Error ? err.message : 'Failed to load';
@@ -532,11 +544,10 @@ export const useStoryStore = create<StoryState>()(
         });
     },
 
-    hasSave: () => {
-      // Synchronous: return true if a save has been made this session
-      const { storyData, saveVersion } = get();
+    hasSave: (slot?: string) => {
+      const { storyData, knownSaves } = get();
       if (!storyData) return false;
-      return saveVersion > 0;
+      return (slot ?? '') in knownSaves;
     },
 
     getSavePayload: (): SavePayload => {

--- a/test/unit/save-manager.test.ts
+++ b/test/unit/save-manager.test.ts
@@ -12,6 +12,7 @@ import {
   quickSave,
   hasQuickSave,
   loadQuickSave,
+  populateKnownSaves,
   exportSave,
   importSave,
   setTitleGenerator,
@@ -497,6 +498,126 @@ describe('save-manager', () => {
       const loaded2 = await loadSave(imported2.meta.id);
       expect(loaded1).toBeDefined();
       expect(loaded2).toBeDefined();
+    });
+  });
+
+  describe('named slot saves', () => {
+    it('quickSave with slot saves to a named slot', async () => {
+      const freshIfid = 'slot-test-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+      const record = await quickSave(
+        freshIfid,
+        ptId,
+        makePayload({ passage: 'Room' }),
+        'my-slot',
+      );
+      expect(record.meta.ifid).toBe(freshIfid);
+
+      const loaded = await loadQuickSave(freshIfid, 'my-slot');
+      expect(loaded).toBeDefined();
+      expect(loaded!.passage).toBe('Room');
+    });
+
+    it('hasQuickSave with slot checks the named slot', async () => {
+      const freshIfid = 'slot-has-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+
+      expect(await hasQuickSave(freshIfid, 'my-slot')).toBe(false);
+      await quickSave(freshIfid, ptId, makePayload(), 'my-slot');
+      expect(await hasQuickSave(freshIfid, 'my-slot')).toBe(true);
+      expect(await hasQuickSave(freshIfid, 'other-slot')).toBe(false);
+      expect(await hasQuickSave(freshIfid)).toBe(false);
+    });
+
+    it('named slot and default slot are independent', async () => {
+      const freshIfid = 'slot-independent-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+
+      await quickSave(freshIfid, ptId, makePayload({ passage: 'Start' }));
+      await quickSave(
+        freshIfid,
+        ptId,
+        makePayload({ passage: 'Room' }),
+        'slot-1',
+      );
+
+      const defaultSave = await loadQuickSave(freshIfid);
+      const slotSave = await loadQuickSave(freshIfid, 'slot-1');
+
+      expect(defaultSave!.passage).toBe('Start');
+      expect(slotSave!.passage).toBe('Room');
+    });
+
+    it('multiple named slots are independent', async () => {
+      const freshIfid = 'slot-multi-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+
+      await quickSave(freshIfid, ptId, makePayload({ passage: 'A' }), 'slot-1');
+      await quickSave(freshIfid, ptId, makePayload({ passage: 'B' }), 'slot-2');
+
+      expect((await loadQuickSave(freshIfid, 'slot-1'))!.passage).toBe('A');
+      expect((await loadQuickSave(freshIfid, 'slot-2'))!.passage).toBe('B');
+    });
+
+    it('quickSave with slot overwrites same slot', async () => {
+      const freshIfid = 'slot-overwrite-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+
+      await quickSave(
+        freshIfid,
+        ptId,
+        makePayload({ passage: 'Old' }),
+        'my-slot',
+      );
+      await quickSave(
+        freshIfid,
+        ptId,
+        makePayload({ passage: 'New' }),
+        'my-slot',
+      );
+
+      const loaded = await loadQuickSave(freshIfid, 'my-slot');
+      expect(loaded!.passage).toBe('New');
+    });
+  });
+
+  describe('populateKnownSaves', () => {
+    it('returns empty when no saves exist', async () => {
+      const freshIfid = 'populate-empty-' + Date.now();
+      const saves = await populateKnownSaves(freshIfid);
+      expect(Object.keys(saves)).toHaveLength(0);
+    });
+
+    it('detects default autosave', async () => {
+      const freshIfid = 'populate-default-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+      await quickSave(freshIfid, ptId, makePayload());
+
+      const saves = await populateKnownSaves(freshIfid);
+      expect(saves['']).toBe(true);
+    });
+
+    it('detects named slot saves', async () => {
+      const freshIfid = 'populate-slots-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+      await quickSave(freshIfid, ptId, makePayload(), 'slot-a');
+      await quickSave(freshIfid, ptId, makePayload(), 'slot-b');
+
+      const saves = await populateKnownSaves(freshIfid);
+      expect(saves['slot-a']).toBe(true);
+      expect(saves['slot-b']).toBe(true);
+      expect('' in saves).toBe(false);
+    });
+
+    it('detects both default and named saves', async () => {
+      const freshIfid = 'populate-both-' + Date.now();
+      const ptId = await startNewPlaythrough(freshIfid);
+      await quickSave(freshIfid, ptId, makePayload());
+      await quickSave(freshIfid, ptId, makePayload(), 'my-slot');
+
+      const saves = await populateKnownSaves(freshIfid);
+      expect(saves['']).toBe(true);
+      expect(saves['my-slot']).toBe(true);
     });
   });
 

--- a/test/unit/store-extended.test.ts
+++ b/test/unit/store-extended.test.ts
@@ -66,9 +66,16 @@ describe('store extended coverage', () => {
       expect(useStoryStore.getState().hasSave()).toBe(false);
     });
 
-    it('hasSave returns true when saveVersion > 0', () => {
-      useStoryStore.setState({ saveVersion: 1 });
+    it('hasSave returns true when knownSaves has default slot', () => {
+      useStoryStore.setState({ knownSaves: { '': true } });
       expect(useStoryStore.getState().hasSave()).toBe(true);
+    });
+
+    it('hasSave with slot returns true only for that slot', () => {
+      useStoryStore.setState({ knownSaves: { 'slot-1': true } });
+      expect(useStoryStore.getState().hasSave('slot-1')).toBe(true);
+      expect(useStoryStore.getState().hasSave('slot-2')).toBe(false);
+      expect(useStoryStore.getState().hasSave()).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- **save(slot?) / load(slot?)**: Pass the `slot` parameter through to the save-manager, using distinct IDB meta keys (`slot.{name}.{ifid}` for named slots vs `autosave.{ifid}` for default)
- **hasSave(slot?)**: Replace the broken `saveVersion` session counter with a `knownSaves` record that is populated from IDB on init, so it survives page reloads and correctly distinguishes between slots
- **Slot index**: Named slots are tracked in a `slotIndex.{ifid}` meta key so `populateKnownSaves` can rediscover them after reload

## Test plan

- [x] Existing 879 tests pass (no regressions)
- [x] New save-manager tests: named slot save/load/has, slot independence, overwrite, populateKnownSaves
- [x] Updated store test: hasSave checks knownSaves per-slot
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)