### PR TITLE
chore: replace release-npm-action with simple release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release:
@@ -23,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - run: bun install --frozen-lockfile
 
@@ -32,7 +32,51 @@ jobs:
       - name: Run tests
         run: bun run test
 
-      - name: Release to npm
-        uses: tobua/release-npm-action@v3
-        with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+
+          # Skip if HEAD is already tagged
+          if git tag --points-at HEAD | grep -qE '^v[0-9]'; then
+            echo "HEAD is already tagged, skipping release."
+            exit 0
+          fi
+
+          # Get latest tag version
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          CURRENT_VERSION=${LATEST_TAG#v}
+
+          # Determine bump type from commits since last tag
+          BUMP="patch"
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=%B 2>/dev/null || git log --pretty=%B)
+          if echo "$COMMITS" | grep -qiE 'BREAKING CHANGE'; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE '^feat(\(|:|!)'; then
+            BUMP="minor"
+          fi
+
+          # Calculate new version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          case $BUMP in
+            major) NEW_VERSION="$((MAJOR+1)).0.0" ;;
+            minor) NEW_VERSION="${MAJOR}.$((MINOR+1)).0" ;;
+            patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))" ;;
+          esac
+
+          echo "Releasing v${NEW_VERSION} (${BUMP} bump from v${CURRENT_VERSION})"
+
+          # Update package.json version locally (no git commit)
+          npm version "${NEW_VERSION}" --no-git-tag-version
+
+          # Publish to npm
+          npm publish
+
+          # Create git tag and GitHub release
+          git tag "v${NEW_VERSION}"
+          git push origin "v${NEW_VERSION}"
+          gh release create "v${NEW_VERSION}" \
+            --title "v${NEW_VERSION}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

Replace `tobua/release-npm-action` with an inline release script that **always publishes on every merge to main**, regardless of commit message format.

Version bump is determined from commits since the last git tag:
- `BREAKING CHANGE` in commit body → **major**
- `feat:` prefix → **minor**
- Everything else (`fix:`, `chore:`, `docs:`, untagged, merge commits) → **patch**

Other details:
- Skips release if HEAD is already tagged (prevents duplicates)
- Creates a git tag (`vX.Y.Z`) and GitHub release with auto-generated notes
- Uses `actions/setup-node` with `registry-url` for npm auth
- Removes dependency on `tobua/release-npm-action`

## Test plan

- [ ] Merge a `feat:` PR → verify minor version bump + npm publish
- [ ] Merge a `chore:` PR → verify patch version bump + npm publish
- [ ] Verify git tag and GitHub release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)