### PR TITLE
fix: accept any valid HTML tag instead of whitelist (#109)

### DIFF
--- a/src/markup/tokenizer.ts
+++ b/src/markup/tokenizer.ts
@@ -53,68 +53,8 @@ export type Token =
   | VariableToken
   | HtmlToken;
 
-const HTML_TAGS = new Set([
-  'a',
-  'article',
-  'aside',
-  'b',
-  'blockquote',
-  'br',
-  'caption',
-  'code',
-  'col',
-  'colgroup',
-  'dd',
-  'del',
-  'details',
-  'dfn',
-  'div',
-  'dl',
-  'dt',
-  'em',
-  'figcaption',
-  'figure',
-  'footer',
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-  'header',
-  'hr',
-  'i',
-  'img',
-  'ins',
-  'kbd',
-  'li',
-  'main',
-  'mark',
-  'nav',
-  'ol',
-  'p',
-  'pre',
-  'q',
-  's',
-  'samp',
-  'section',
-  'small',
-  'span',
-  'strong',
-  'sub',
-  'summary',
-  'sup',
-  'table',
-  'tbody',
-  'td',
-  'tfoot',
-  'th',
-  'thead',
-  'tr',
-  'u',
-  'ul',
-  'wbr',
-]);
+/** Tag name must start with a letter (covers standard and custom elements). */
+const VALID_TAG_START = /[a-zA-Z]/;
 
 const HTML_VOID_TAGS = new Set(['br', 'col', 'hr', 'img', 'wbr']);
 
@@ -661,13 +601,26 @@ export function tokenize(input: string): Token[] {
       const isClose = input[j] === '/';
       if (isClose) j++;
 
-      // Read tag name
+      // Read tag name (letters, digits, hyphens for custom elements)
       const tagStart = j;
-      while (j < input.length && /[a-zA-Z0-9]/.test(input[j]!)) j++;
+      while (j < input.length && /[a-zA-Z0-9-]/.test(input[j]!)) j++;
       const tag = input.slice(tagStart, j).toLowerCase();
 
-      // Only handle known HTML tags
-      if (tag && HTML_TAGS.has(tag)) {
+      // Valid tag name must start with a letter
+      if (tag && VALID_TAG_START.test(tag[0]!)) {
+        // SVG is its own world — treat <svg>…</svg> as opaque text
+        // so the markdown pipeline handles it with proper namespace.
+        if (tag === 'svg' && !isClose) {
+          const closeTag = '</svg>';
+          const closeIdx = input.indexOf(closeTag, j);
+          if (closeIdx !== -1) {
+            const end = closeIdx + closeTag.length;
+            // Leave the entire <svg>…</svg> block as text
+            i = end;
+            continue;
+          }
+        }
+
         if (isClose) {
           // Closing tag: skip whitespace, expect >
           while (j < input.length && /\s/.test(input[j]!)) j++;

--- a/test/unit/html-nesting.test.tsx
+++ b/test/unit/html-nesting.test.tsx
@@ -43,6 +43,54 @@ const shellContent =
 const sidebarContent =
   '<div class="sidebar"><div class="nav"><div class="item">Home</div><div class="item">Settings</div><div class="item">About</div></div><div class="footer">v1.0</div></div>';
 
+describe('issue #109: <button> elements should not be HTML-escaped', () => {
+  it('tokenizes <button> as an HtmlNode', () => {
+    const ast = parse('<button>Click me</button>');
+    expect(ast).toHaveLength(1);
+    expect((ast[0] as HtmlNode).type).toBe('html');
+    expect((ast[0] as HtmlNode).tag).toBe('button');
+  });
+
+  it('tokenizes <button> with attributes', () => {
+    const ast = parse('<button class="action" disabled>Go</button>');
+    expect(ast).toHaveLength(1);
+    expect((ast[0] as HtmlNode).tag).toBe('button');
+    expect((ast[0] as HtmlNode).attributes['class']).toBe('action');
+  });
+
+  it('renders <button> inside {for} loop in nobr context', () => {
+    const storyData = makeStoryData([
+      makePassage(
+        1,
+        'Start',
+        '{for @item of $items}<button>{@item.name}</button>{/for}',
+        ['nobr'],
+      ),
+    ]);
+    useStoryStore.getState().init(storyData);
+    useStoryStore.setState({ nobr: true });
+    useStoryStore
+      .getState()
+      .setVariable('items', [{ name: 'Test' }, { name: 'Other' }]);
+
+    const passage = useStoryStore.getState().storyData!.passages.get('Start')!;
+    const container = document.createElement('div');
+    render(
+      <NobrContext.Provider value={true}>
+        <Passage passage={passage} />
+      </NobrContext.Provider>,
+      container,
+    );
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].textContent).toBe('Test');
+    expect(buttons[1].textContent).toBe('Other');
+    // Ensure no escaped HTML
+    expect(container.innerHTML).not.toContain('&lt;button');
+  });
+});
+
 describe('issue #61: deeply nested HTML with {include}', () => {
   describe('tokenize + buildAST (unit level)', () => {
     it('parses DialogShell passage', () => {


### PR DESCRIPTION
## Summary
- Replace the hardcoded 60-entry `HTML_TAGS` whitelist with a simple validity check (tag name starts with a letter), so any standard or custom HTML element works without needing to be listed
- Treat `<svg>…</svg>` blocks as opaque text, letting the markdown pipeline handle them with proper SVG namespace
- Add tests for `<button>` tokenization and rendering inside `{for}` loops in `[nobr]` passages

## Test plan
- [x] Unit: `<button>` tokenizes as HtmlNode
- [x] Unit: `<button>` with attributes parses correctly
- [x] DOM: `<button>` inside `{for}` loop in `[nobr]` context renders real DOM elements (not escaped text)
- [x] Existing SVG rendering test still passes
- [x] Full suite: 968 tests pass

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)