### PR TITLE
fix: evaluate complex expressions in interpolation context

### DIFF
--- a/src/components/macros/ExprDisplay.tsx
+++ b/src/components/macros/ExprDisplay.tsx
@@ -1,0 +1,39 @@
+import { useContext } from 'preact/hooks';
+import { useStoryStore } from '../../store';
+import { evaluate } from '../../expression';
+import { LocalsValuesContext } from '../../markup/render';
+import { useInterpolate } from '../../hooks/use-interpolate';
+
+interface ExprDisplayProps {
+  expression: string;
+  className?: string;
+  id?: string;
+}
+
+export function ExprDisplay({ expression, className, id }: ExprDisplayProps) {
+  const resolve = useInterpolate();
+  className = resolve(className);
+  id = resolve(id);
+  const localsValues = useContext(LocalsValuesContext);
+  const variables = useStoryStore((s) => s.variables);
+  const temporary = useStoryStore((s) => s.temporary);
+
+  let display: string;
+  try {
+    const value = evaluate(expression, variables, temporary, localsValues);
+    display = value == null ? '' : String(value);
+  } catch {
+    display = `{error: ${expression}}`;
+  }
+
+  if (className || id)
+    return (
+      <span
+        id={id}
+        class={className}
+      >
+        {display}
+      </span>
+    );
+  return <>{display}</>;
+}

--- a/src/interpolation.ts
+++ b/src/interpolation.ts
@@ -1,5 +1,7 @@
-const INTERP_RE = /\{(\$[\w.]+|_[\w.]+|@[\w.]+)\}/g;
-const INTERP_TEST = /\{[\$_@][\w.]+\}/;
+import { evaluate } from './expression';
+
+/** Detects any {…} block that starts with a sigil ($, _, @). */
+const INTERP_TEST = /\{[\$_@]\w/;
 
 export function hasInterpolation(s: string): boolean {
   return INTERP_TEST.test(s);
@@ -14,31 +16,107 @@ function resolveDotPath(root: unknown, parts: string[]): unknown {
   return value;
 }
 
+/**
+ * Evaluate an expression string and return its stringified result.
+ * Uses the full expression evaluator from expression.ts.
+ */
+export function interpolateExpression(
+  expr: string,
+  variables: Record<string, unknown>,
+  temporary: Record<string, unknown>,
+  locals: Record<string, unknown>,
+): string {
+  const value = evaluate(expr, variables, temporary, locals);
+  return value == null ? '' : String(value);
+}
+
+function resolveSimple(
+  ref: string,
+  variables: Record<string, unknown>,
+  temporary: Record<string, unknown>,
+  locals: Record<string, unknown>,
+): string {
+  const prefix = ref[0]!;
+  const path = ref.slice(1);
+  const parts = path.split('.');
+  const root = parts[0]!;
+
+  let value: unknown;
+  if (prefix === '$') {
+    value = variables[root];
+  } else if (prefix === '_') {
+    value = temporary[root];
+  } else {
+    value = locals[root];
+  }
+
+  if (parts.length > 1) {
+    value = resolveDotPath(value, parts);
+  }
+
+  return value == null ? '' : String(value);
+}
+
 export function interpolate(
   template: string,
   variables: Record<string, unknown>,
   temporary: Record<string, unknown>,
   locals: Record<string, unknown>,
 ): string {
-  return template.replace(INTERP_RE, (_match, ref: string) => {
-    const prefix = ref[0]!;
-    const path = ref.slice(1);
-    const parts = path.split('.');
-    const root = parts[0]!;
+  // Manual scan: process {…} blocks containing sigils.
+  // Simple dot-path refs use the fast resolver; everything else falls back
+  // to the full expression evaluator.
+  let result = '';
+  let i = 0;
 
-    let value: unknown;
-    if (prefix === '$') {
-      value = variables[root];
-    } else if (prefix === '_') {
-      value = temporary[root];
+  while (i < template.length) {
+    if (template[i] !== '{') {
+      // Accumulate plain text
+      const nextBrace = template.indexOf('{', i);
+      if (nextBrace === -1) {
+        result += template.slice(i);
+        break;
+      }
+      result += template.slice(i, nextBrace);
+      i = nextBrace;
+      continue;
+    }
+
+    // Found { — check if it starts a sigil expression
+    i++; // skip {
+
+    const sigil = template[i];
+    if (sigil !== '$' && sigil !== '_' && sigil !== '@') {
+      // Not an interpolation — emit the { as text
+      result += '{';
+      continue;
+    }
+
+    // Scan for balanced closing }
+    let depth = 1;
+    let j = i;
+    while (j < template.length && depth > 0) {
+      j++;
+      if (template[j] === '{') depth++;
+      else if (template[j] === '}') depth--;
+    }
+
+    if (depth !== 0) {
+      // Unbalanced — emit as text
+      result += '{';
+      continue;
+    }
+
+    const inner = template.slice(i, j);
+    i = j + 1; // skip past closing }
+
+    // Try simple dot-path match first
+    if (/^[\$_@][\w.]+$/.test(inner)) {
+      result += resolveSimple(inner, variables, temporary, locals);
     } else {
-      value = locals[root];
+      result += interpolateExpression(inner, variables, temporary, locals);
     }
+  }
 
-    if (parts.length > 1) {
-      value = resolveDotPath(value, parts);
-    }
-
-    return value == null ? '' : String(value);
-  });
+  return result;
 }

--- a/src/markup/ast.ts
+++ b/src/markup/ast.ts
@@ -13,6 +13,13 @@ export interface VariableNode {
   id?: string;
 }
 
+export interface ExpressionNode {
+  type: 'expression';
+  expression: string;
+  className?: string;
+  id?: string;
+}
+
 export interface Branch {
   rawArgs: string;
   className?: string;
@@ -37,7 +44,12 @@ export interface HtmlNode {
   children: ASTNode[];
 }
 
-export type ASTNode = TextNode | VariableNode | MacroNode | HtmlNode;
+export type ASTNode =
+  | TextNode
+  | VariableNode
+  | ExpressionNode
+  | MacroNode
+  | HtmlNode;
 
 /** Macros that require a closing tag and can contain children */
 const BLOCK_MACROS = new Set([
@@ -128,6 +140,17 @@ export function buildAST(tokens: Token[]): ASTNode[] {
         if (token.className) varNode.className = token.className;
         if (token.id) varNode.id = token.id;
         current().push(varNode);
+        break;
+      }
+
+      case 'expression': {
+        const exprNode: ExpressionNode = {
+          type: 'expression',
+          expression: token.expression,
+        };
+        if (token.className) exprNode.className = token.className;
+        if (token.id) exprNode.id = token.id;
+        current().push(exprNode);
         break;
       }
 

--- a/src/markup/render.tsx
+++ b/src/markup/render.tsx
@@ -1,6 +1,7 @@
 import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 import { VarDisplay } from '../components/macros/VarDisplay';
+import { ExprDisplay } from '../components/macros/ExprDisplay';
 import { WidgetInvocation } from '../components/macros/WidgetInvocation';
 import { getWidget } from '../widgets/widget-registry';
 import { getMacro, isSubMacro } from '../registry';
@@ -176,6 +177,16 @@ function renderSingleNode(
           key={key}
           name={node.name}
           scope={node.scope}
+          className={node.className}
+          id={node.id}
+        />
+      );
+
+    case 'expression':
+      return (
+        <ExprDisplay
+          key={key}
+          expression={node.expression}
           className={node.className}
           id={node.id}
         />

--- a/src/markup/tokenizer.ts
+++ b/src/markup/tokenizer.ts
@@ -36,6 +36,15 @@ export interface VariableToken {
   end: number;
 }
 
+export interface ExpressionToken {
+  type: 'expression';
+  expression: string;
+  className?: string;
+  id?: string;
+  start: number;
+  end: number;
+}
+
 export interface HtmlToken {
   type: 'html';
   tag: string;
@@ -51,6 +60,7 @@ export type Token =
   | LinkToken
   | MacroToken
   | VariableToken
+  | ExpressionToken
   | HtmlToken;
 
 /** Tag name must start with a letter (covers standard and custom elements). */
@@ -234,6 +244,20 @@ function parseHtmlAttributes(
 }
 
 /**
+ * Scan for the balanced closing } starting at position i (just past the {).
+ * Returns the index of the closing } or -1 if unbalanced.
+ */
+function scanBalancedBrace(input: string, i: number): number {
+  let depth = 1;
+  while (i < input.length && depth > 0) {
+    if (input[i] === '{') depth++;
+    else if (input[i] === '}') depth--;
+    if (depth > 0) i++;
+  }
+  return depth === 0 ? i : -1;
+}
+
+/**
  * Single-pass tokenizer for Twine passage content.
  * Recognizes: [[links]], {$variable}, {_temporary}, {macroName args}
  */
@@ -341,7 +365,7 @@ export function tokenize(input: string): Token[] {
         const charAfter = input[afterSelectors];
 
         if (charAfter === '$') {
-          // {.class#id $variable.field}
+          // {.class#id $variable.field} or {.class $expr[...]}
           i = afterSelectors + 1;
           const nameStart = i;
           while (i < input.length && /[\w.]/.test(input[i]!)) i++;
@@ -362,14 +386,31 @@ export function tokenize(input: string): Token[] {
             textStart = i;
             continue;
           }
-          // Not valid — treat as text
+          // Complex expression — scan for balanced closing }
+          const closeIdx$ = scanBalancedBrace(input, nameStart);
+          if (closeIdx$ !== -1) {
+            const expression = input.slice(afterSelectors, closeIdx$);
+            i = closeIdx$ + 1;
+            const token: ExpressionToken = {
+              type: 'expression',
+              expression,
+              start,
+              end: i,
+            };
+            if (className) token.className = className;
+            if (id) token.id = id;
+            tokens.push(token);
+            textStart = i;
+            continue;
+          }
+          // Unbalanced — treat as text
           i = start + 1;
           textStart = start;
           continue;
         }
 
         if (charAfter === '_') {
-          // {.class#id _temporary.field}
+          // {.class#id _temporary.field} or {.class _expr[...]}
           i = afterSelectors + 1;
           const nameStart = i;
           while (i < input.length && /[\w.]/.test(input[i]!)) i++;
@@ -390,14 +431,31 @@ export function tokenize(input: string): Token[] {
             textStart = i;
             continue;
           }
-          // Not valid — treat as text
+          // Complex expression — scan for balanced closing }
+          const closeIdx_ = scanBalancedBrace(input, nameStart);
+          if (closeIdx_ !== -1) {
+            const expression = input.slice(afterSelectors, closeIdx_);
+            i = closeIdx_ + 1;
+            const token: ExpressionToken = {
+              type: 'expression',
+              expression,
+              start,
+              end: i,
+            };
+            if (className) token.className = className;
+            if (id) token.id = id;
+            tokens.push(token);
+            textStart = i;
+            continue;
+          }
+          // Unbalanced — treat as text
           i = start + 1;
           textStart = start;
           continue;
         }
 
         if (charAfter === '@') {
-          // {.class#id @local.field}
+          // {.class#id @local.field} or {.class @expr[...]}
           i = afterSelectors + 1;
           const nameStart = i;
           while (i < input.length && /[\w.]/.test(input[i]!)) i++;
@@ -418,7 +476,24 @@ export function tokenize(input: string): Token[] {
             textStart = i;
             continue;
           }
-          // Not valid — treat as text
+          // Complex expression — scan for balanced closing }
+          const closeIdx_at = scanBalancedBrace(input, nameStart);
+          if (closeIdx_at !== -1) {
+            const expression = input.slice(afterSelectors, closeIdx_at);
+            i = closeIdx_at + 1;
+            const token: ExpressionToken = {
+              type: 'expression',
+              expression,
+              start,
+              end: i,
+            };
+            if (className) token.className = className;
+            if (id) token.id = id;
+            tokens.push(token);
+            textStart = i;
+            continue;
+          }
+          // Unbalanced — treat as text
           i = start + 1;
           textStart = start;
           continue;
@@ -468,7 +543,7 @@ export function tokenize(input: string): Token[] {
         continue;
       }
 
-      // {$variable} or {$variable.field.subfield}
+      // {$variable} or {$variable.field.subfield} or {$expr[...]}
       if (nextChar === '$') {
         flushText(i);
         i += 2;
@@ -488,13 +563,27 @@ export function tokenize(input: string): Token[] {
           textStart = i;
           continue;
         }
-        // Not a valid variable token — treat as text
+        // Complex expression — scan for balanced closing }
+        const closeIdx = scanBalancedBrace(input, nameStart);
+        if (closeIdx !== -1) {
+          const expression = input.slice(start + 1, closeIdx);
+          i = closeIdx + 1;
+          tokens.push({
+            type: 'expression',
+            expression,
+            start,
+            end: i,
+          });
+          textStart = i;
+          continue;
+        }
+        // Unbalanced — treat as text
         i = start + 1;
         textStart = start;
         continue;
       }
 
-      // {_temporary.field}
+      // {_temporary.field} or {_expr[...]}
       if (nextChar === '_') {
         flushText(i);
         i += 2;
@@ -514,13 +603,27 @@ export function tokenize(input: string): Token[] {
           textStart = i;
           continue;
         }
-        // Not a valid temporary token — treat as text
+        // Complex expression — scan for balanced closing }
+        const closeIdx = scanBalancedBrace(input, nameStart);
+        if (closeIdx !== -1) {
+          const expression = input.slice(start + 1, closeIdx);
+          i = closeIdx + 1;
+          tokens.push({
+            type: 'expression',
+            expression,
+            start,
+            end: i,
+          });
+          textStart = i;
+          continue;
+        }
+        // Unbalanced — treat as text
         i = start + 1;
         textStart = start;
         continue;
       }
 
-      // {@local.field}
+      // {@local.field} or {@expr[...]}
       if (nextChar === '@') {
         flushText(i);
         i += 2;
@@ -540,7 +643,21 @@ export function tokenize(input: string): Token[] {
           textStart = i;
           continue;
         }
-        // Not a valid local token — treat as text
+        // Complex expression — scan for balanced closing }
+        const closeIdx = scanBalancedBrace(input, nameStart);
+        if (closeIdx !== -1) {
+          const expression = input.slice(start + 1, closeIdx);
+          i = closeIdx + 1;
+          tokens.push({
+            type: 'expression',
+            expression,
+            start,
+            end: i,
+          });
+          textStart = i;
+          continue;
+        }
+        // Unbalanced — treat as text
         i = start + 1;
         textStart = start;
         continue;

--- a/test/unit/interpolation.test.ts
+++ b/test/unit/interpolation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { hasInterpolation, interpolate } from '../../src/interpolation';
+import {
+  hasInterpolation,
+  interpolate,
+  interpolateExpression,
+} from '../../src/interpolation';
 
 describe('hasInterpolation', () => {
   it('returns false for plain text', () => {
@@ -74,5 +78,87 @@ describe('interpolate', () => {
 
   it('handles null/undefined nested paths gracefully', () => {
     expect(interpolate('{$a.b.c}', { a: null }, {}, {})).toBe('');
+  });
+
+  it('resolves bracket access {$arr[$i]} via expression evaluator', () => {
+    expect(
+      interpolate('val-{$arr[$i]}', { arr: ['a', 'b', 'c'], i: 1 }, {}, {}),
+    ).toBe('val-b');
+  });
+
+  it('resolves bracket access with @locals', () => {
+    expect(
+      interpolate(
+        '{@labels[@level]}',
+        {},
+        {},
+        { labels: { high: 'HIGH' }, level: 'high' },
+      ),
+    ).toBe('HIGH');
+  });
+
+  it('resolves nullish coalescing in interpolation', () => {
+    expect(
+      interpolate(
+        '{$map[$key] ?? "default"}',
+        { map: {}, key: 'missing' },
+        {},
+        {},
+      ),
+    ).toBe('default');
+  });
+
+  it('resolves ternary in interpolation', () => {
+    expect(interpolate('{$x != null ? $x : 0}', { x: null }, {}, {})).toBe('0');
+  });
+
+  it('mixes simple and complex interpolations', () => {
+    expect(
+      interpolate(
+        '{$name}: {$scores[$i]}',
+        { name: 'Hero', scores: [10, 20, 30], i: 2 },
+        {},
+        {},
+      ),
+    ).toBe('Hero: 30');
+  });
+});
+
+describe('hasInterpolation — complex expressions', () => {
+  it('detects bracket access {$arr[$i]}', () => {
+    expect(hasInterpolation('{$arr[$i]}')).toBe(true);
+  });
+
+  it('detects nullish coalescing with sigils', () => {
+    expect(hasInterpolation('{@a ?? @b}')).toBe(true);
+  });
+
+  it('detects ternary with sigils', () => {
+    expect(hasInterpolation('{$x != null ? $x : 0}')).toBe(true);
+  });
+
+  it('still returns false for plain text', () => {
+    expect(hasInterpolation('no sigils here')).toBe(false);
+  });
+
+  it('still returns false for {notavar}', () => {
+    expect(hasInterpolation('{notavar}')).toBe(false);
+  });
+});
+
+describe('interpolateExpression', () => {
+  it('evaluates a complex expression and returns string', () => {
+    expect(
+      interpolateExpression(
+        '@labels[@level]',
+        {},
+        {},
+        { labels: { high: 'HIGH' }, level: 'high' },
+      ),
+    ).toBe('HIGH');
+  });
+
+  it('returns empty string for null/undefined result', () => {
+    expect(interpolateExpression('$missing', {}, {}, {})).toBe('');
   });
 });

--- a/test/unit/tokenizer.test.ts
+++ b/test/unit/tokenizer.test.ts
@@ -916,6 +916,118 @@ describe('tokenize', () => {
     });
   });
 
+  describe('expression tokens', () => {
+    it('parses bracket access {$arr[$i]} as expression token', () => {
+      const tokens = tokenize('{$arr[$i]}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '$arr[$i]',
+          start: 0,
+          end: 10,
+        },
+      ]);
+    });
+
+    it('parses nested bracket access {@p.labels[@p.level]}', () => {
+      const tokens = tokenize('{@p.labels[@p.level]}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '@p.labels[@p.level]',
+          start: 0,
+          end: 21,
+        },
+      ]);
+    });
+
+    it('parses expression with nullish coalescing', () => {
+      const tokens = tokenize('{@p.labels[@p.level] ?? @p.level}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '@p.labels[@p.level] ?? @p.level',
+          start: 0,
+          end: 33,
+        },
+      ]);
+    });
+
+    it('parses expression with ternary', () => {
+      const tokens = tokenize('{$x != null ? $x : 0}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '$x != null ? $x : 0',
+          start: 0,
+          end: 21,
+        },
+      ]);
+    });
+
+    it('parses _temporary bracket access as expression', () => {
+      const tokens = tokenize('{_actions[$i].name}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '_actions[$i].name',
+          start: 0,
+          end: 19,
+        },
+      ]);
+    });
+
+    it('keeps simple {$var} as variable token (regression)', () => {
+      const tokens = tokenize('{$health}');
+      expect(tokens[0]).toMatchObject({ type: 'variable', name: 'health' });
+    });
+
+    it('keeps simple {$var.path} as variable token (regression)', () => {
+      const tokens = tokenize('{$player.name}');
+      expect(tokens[0]).toMatchObject({
+        type: 'variable',
+        name: 'player.name',
+      });
+    });
+
+    it('handles expression token in surrounding text', () => {
+      const tokens = tokenize('Level: {@p.labels[@p.level]} ok');
+      expect(tokens).toHaveLength(3);
+      expect(tokens[0]).toMatchObject({ type: 'text', value: 'Level: ' });
+      expect(tokens[1]).toMatchObject({
+        type: 'expression',
+        expression: '@p.labels[@p.level]',
+      });
+      expect(tokens[2]).toMatchObject({ type: 'text', value: ' ok' });
+    });
+
+    it('parses {.class $expr[...]} with selector prefix as expression', () => {
+      const tokens = tokenize('{.highlight $arr[$i]}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '$arr[$i]',
+          className: 'highlight',
+          start: 0,
+          end: 21,
+        },
+      ]);
+    });
+
+    it('parses {#id @expr[...]} with id prefix as expression', () => {
+      const tokens = tokenize('{#val @map[@key]}');
+      expect(tokens).toEqual([
+        {
+          type: 'expression',
+          expression: '@map[@key]',
+          id: 'val',
+          start: 0,
+          end: 17,
+        },
+      ]);
+    });
+  });
+
   describe('mixed content', () => {
     it('handles text, variables, links, and macros together', () => {
       const input = 'Hello {$name}! {set $seen = true}Go to [[Next]]';


### PR DESCRIPTION
## Summary

- Fixes `{@p.labels[@p.level]}`, `{$arr[$i]}`, ternaries, nullish coalescing, and other complex expressions that were silently rendered as raw text in both passage body and HTML attribute interpolation contexts
- Adds `expression` token/node types so the tokenizer falls back to balanced-brace scanning when the simple `[\w.]+` path pattern doesn't match
- Routes complex expressions through the full `evaluate()` engine at render time via new `ExprDisplay` component
- Rewrites `interpolate()` from regex-based to manual scanning so HTML attribute interpolation also handles complex expressions

## Test plan

- [x] 10 new tokenizer tests for expression tokens (bracket access, ternary, nullish coalescing, selector prefixes, regression for simple vars)
- [x] 8 new interpolation tests (bracket access, @locals, nullish coalescing, ternary, mixed simple+complex, `interpolateExpression`, `hasInterpolation` for complex exprs)
- [x] All 1019 existing tests pass — zero regressions
- [x] `tsc --noEmit` clean

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)