### PR TITLE
fix: preserve renderDeferred set during beforerestart handler

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -516,7 +516,16 @@ export const useStoryStore = create<StoryState>()(
       const startPassage = storyData.passagesById.get(storyData.startNode);
       if (!startPassage) return;
 
+      // Reset renderDeferred before firing beforerestart so we can detect
+      // if a handler called deferRender() during the callback.
+      set((state) => {
+        state.renderDeferred = false;
+      });
+
       fireBeforeRestart();
+
+      const keepDeferred = get().renderDeferred;
+
       resetPRNG();
       resetTriggers();
       const initialVars = deepClone(variableDefaults);
@@ -535,7 +544,9 @@ export const useStoryStore = create<StoryState>()(
         state.historyIndex = 0;
         state.visitCounts = { [startPassage.name]: 1 };
         state.renderCounts = { [startPassage.name]: 1 };
-        state.renderDeferred = false;
+        if (!keepDeferred) {
+          state.renderDeferred = false;
+        }
       });
 
       lastNavigationVars = get().variables;

--- a/test/unit/store.test.ts
+++ b/test/unit/store.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useStoryStore } from '../../src/store';
+import { useStoryStore, onBeforeRestart } from '../../src/store';
 import { executeStoryInit } from '../../src/story-init';
 import type { StoryData, Passage } from '../../src/parser';
 import { registerClass, clearRegistry } from '../../src/class-registry';
@@ -869,6 +869,17 @@ describe('useStoryStore', () => {
       expect(useStoryStore.getState().renderDeferred).toBe(true);
       useStoryStore.getState().restart();
       expect(useStoryStore.getState().renderDeferred).toBe(false);
+    });
+
+    it('restart() preserves renderDeferred if set during beforerestart', () => {
+      const story = makeStoryData([makePassage(1, 'Start', '')]);
+      useStoryStore.getState().init(story);
+      const unsub = onBeforeRestart(() => {
+        useStoryStore.getState().deferRender();
+      });
+      useStoryStore.getState().restart();
+      expect(useStoryStore.getState().renderDeferred).toBe(true);
+      unsub();
     });
   });
 });


### PR DESCRIPTION
## Summary

- `restart()` unconditionally set `renderDeferred = false`, overriding any `Story.deferRender()` call made in a `beforerestart` handler
- Now resets `renderDeferred` before firing callbacks, then checks if a handler set it back to `true` and preserves that state through the restart
- Enables the deferred-render pattern for async restart workflows (e.g. showing `StoryLoading` while an engine rebuilds)

Closes #126

## Test plan

- [x] New test: `restart() preserves renderDeferred if set during beforerestart`
- [x] Existing test: `restart() resets renderDeferred to false` (no handler) still passes
- [x] Full suite: 1025 tests pass
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)