### PR TITLE
fix: exclude superpowers docs from VitePress build

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   description: 'A Preact-based story format for Twine 2.',
   base: '/spindle/',
   appearance: true,
+  srcExclude: ['superpowers/**'],
 
   head: [['meta', { name: 'theme-color', content: '#6366f1' }]],
 


### PR DESCRIPTION
## Summary

- Add `srcExclude: ['superpowers/**']` to VitePress config to exclude internal plan/spec files from the docs build
- Fixes `docs:build` failure caused by Vue template compiler choking on HTML code blocks in `docs/superpowers/plans/2026-03-27-transient-variables.md` ("Duplicate attribute" error at line 1135)

## Test plan

- [x] `bun run docs:build` passes cleanly
- [x] No change to published documentation (superpowers files are internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)